### PR TITLE
CI and Docker build improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,23 +34,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:17
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: deesl_test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     env:
-      DATABASE_URL: postgres://postgres:postgres@localhost/deesl_test
       GOOGLE_CLIENT_ID: placeholder
       GOOGLE_CLIENT_SECRET: placeholder
 
@@ -72,12 +56,6 @@ jobs:
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libpq-dev
-
-      - name: Install diesel CLI
-        run: cargo install diesel_cli --no-default-features --features postgres
-
-      - name: Run migrations
-        run: diesel migration run
 
       - name: Run tests
         run: cargo test --all-features

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,6 +29,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract app version
+        id: cargo-version
+        run: echo "version=$(grep -m1 '^version' Cargo.toml | sed 's/.*= *\"//;s/\"//')" >> "$GITHUB_OUTPUT"
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -39,6 +43,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=sha-,format=short
+            type=raw,value=${{ steps.cargo-version.outputs.version }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,6 @@ RUN apt-get update && apt-get install -y \
     libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN cargo install diesel_cli --no-default-features --features postgres
-
 WORKDIR /app
 
 COPY Cargo.toml Cargo.lock ./
@@ -30,6 +28,8 @@ RUN mkdir -p src && echo "fn main() {}" > src/main.rs
 
 # Build only dependencies - layer caching optimisation
 RUN cargo build --release
+
+RUN cargo install diesel_cli --no-default-features --features postgres
 
 COPY . .
 RUN touch src/main.rs
@@ -46,8 +46,6 @@ RUN apt-get update && apt-get install -y \
     libpq5 \
     curl \
     && rm -rf /var/lib/apt/lists/*
-
-RUN cargo install diesel_cli --no-default-features --features postgres || true
 
 WORKDIR /app
 


### PR DESCRIPTION
- CI (lint + test) now only runs on pull requests, not on pushes to main
- Removed unnecessary Postgres service, diesel CLI install, and migrations from the test job — unit tests have no DB dependency
- Improved Dockerfile layer caching: moved `diesel_cli` install to its own layer after dependency compilation, removed broken `cargo install || true` from the runtime stage
- Added `Cargo.toml` app version as a Docker image tag on every build, not just on `v*` git tag pushes