### PR TITLE
Frontend TODOs: Logout fix, version footer, last-used vehicle, datetime picker

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,5 +1,8 @@
 # TODOs
 
-- [ ] Add cache busting for assets
-- [ ] Add bulk import from file
+- [ ] Frontend: Fix logout after login, when you log in it puts the token in the URL and it stays there, when you log out and refresh it stays logged in. This is only an issue when the details are in the URL
+- [ ] Frontend: Add cache busting for assets, and include version in UI somewhere subtle
+- [ ] Frontend: Populate last-used vehicle by default for fuel entries
+- [ ] Frontend: Add date and time picker for fuel transactions so they can be back-dated
+- [ ] Add bulk transaction import from file
 - [ ] Vehicle sharing with other users (with read/write permission levels)

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,8 +1,8 @@
 # TODOs
 
-- [ ] Frontend: Fix logout after login, when you log in it puts the token in the URL and it stays there, when you log out and refresh it stays logged in. This is only an issue when the details are in the URL
-- [ ] Frontend: Add cache busting for assets, and include version in UI somewhere subtle
-- [ ] Frontend: Populate last-used vehicle by default for fuel entries
-- [ ] Frontend: Add date and time picker for fuel transactions so they can be back-dated
+- [x] Frontend: Fix logout after login, when you log in it puts the token in the URL and it stays there, when you log out and refresh it stays logged in. This is only an issue when the details are in the URL
+- [x] Frontend: Add cache busting for assets, and include version in UI somewhere subtle
+- [x] Frontend: Populate last-used vehicle by default for fuel entries
+- [x] Frontend: Add date and time picker for fuel transactions so they can be back-dated
 - [ ] Add bulk transaction import from file
 - [ ] Vehicle sharing with other users (with read/write permission levels)

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,6 +5,7 @@ import { useAuth } from './composables/useAuth';
 import { useCurrency } from './composables/useCurrency';
 import Login from './components/Login.vue';
 import UserSettings from './components/UserSettings.vue';
+import AppFooter from './components/AppFooter.vue';
 
 const { isLoggedIn, email, userId, token, logout, initFromRedirect } = useAuth();
 const { loadCurrency } = useCurrency();
@@ -43,6 +44,7 @@ watch(
         <Login />
       </div>
     </main>
+    <AppFooter />
   </div>
 </template>
 

--- a/frontend/src/components/AddFuelEntryForm.vue
+++ b/frontend/src/components/AddFuelEntryForm.vue
@@ -17,6 +17,7 @@ const selectedStationId = ref(null);
 const mileage = ref('');
 const litres = ref('');
 const cost = ref('');
+const filledAt = ref(new Date().toISOString().slice(0, 16));
 const error = ref('');
 const loading = ref(false);
 const showDropdown = ref(false);
@@ -54,13 +55,15 @@ async function handleSubmit() {
       mileageVal,
       litresVal,
       costVal,
-      token.value
+      token.value,
+      filledAt.value ? new Date(filledAt.value).toISOString() : null
     );
     mileage.value = '';
     litres.value = '';
     cost.value = '';
     stationQuery.value = '';
     selectedStationId.value = null;
+    filledAt.value = new Date().toISOString().slice(0, 16);
     emit('success');
   } catch (e) {
     error.value = e.message;
@@ -107,6 +110,10 @@ function hideDropdown() {
     <label>
       <span>Cost</span>
       <input type="number" step="0.01" v-model="cost" placeholder="Total cost" :disabled="loading" />
+    </label>
+    <label>
+      <span>Date/Time (optional)</span>
+      <input type="datetime-local" v-model="filledAt" :disabled="loading" />
     </label>
     <button type="submit" :disabled="loading">
       {{ loading ? 'Saving...' : 'Add Entry' }}

--- a/frontend/src/components/AppFooter.vue
+++ b/frontend/src/components/AppFooter.vue
@@ -1,0 +1,37 @@
+<script setup>
+import { ref, onMounted } from 'vue';
+import { getVersion } from '../services/version';
+
+const version = ref('');
+const error = ref('');
+
+onMounted(async () => {
+  try {
+    const data = await getVersion();
+    version.value = data.version;
+  } catch (e) {
+    error.value = '';
+    // Silently fail - version is not critical
+  }
+});
+</script>
+
+<template>
+  <footer class="app-footer">
+    <span v-if="version" class="version">v{{ version }}</span>
+  </footer>
+</template>
+
+<style scoped>
+.app-footer {
+  padding: 16px 0;
+  text-align: center;
+  border-top: 1px solid #ddd;
+  margin-top: 24px;
+}
+
+.version {
+  font-size: 0.75rem;
+  color: #999;
+}
+</style>

--- a/frontend/src/components/Dashboard.vue
+++ b/frontend/src/components/Dashboard.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, computed } from 'vue';
 import { useAuth } from '../composables/useAuth';
 import { listVehicles } from '../services/vehicles';
 import { listFuelStations, listRecentFuelEntries } from '../services/fuelEntries';
@@ -14,6 +14,11 @@ const recentEntries = ref([]);
 const loading = ref(true);
 const error = ref('');
 const showQuickAdd = ref(false);
+
+const lastUsedVehicleId = computed(() => {
+  if (recentEntries.value.length === 0) return null;
+  return recentEntries.value[0].vehicle_id;
+});
 
 async function loadData() {
   try {
@@ -62,6 +67,7 @@ onMounted(loadData);
           v-if="showQuickAdd"
           :vehicles="vehicles"
           :stations="stations"
+          :default-vehicle-id="lastUsedVehicleId || (vehicles.length > 0 ? vehicles[0].id : null)"
           @success="showQuickAdd = false; loadRecentEntries()"
         />
 

--- a/frontend/src/components/QuickAddFuelForm.vue
+++ b/frontend/src/components/QuickAddFuelForm.vue
@@ -6,13 +6,14 @@ import { useAuth } from '../composables/useAuth';
 const props = defineProps({
   vehicles: Array,
   stations: Array,
+  defaultVehicleId: Number,
 });
 
 const emit = defineEmits(['success']);
 
 const { token } = useAuth();
 
-const selectedVehicleId = ref('');
+const selectedVehicleId = ref(props.defaultVehicleId ? props.defaultVehicleId.toString() : '');
 const stationQuery = ref('');
 const selectedStationId = ref(null);
 const mileage = ref('');

--- a/frontend/src/components/QuickAddFuelForm.vue
+++ b/frontend/src/components/QuickAddFuelForm.vue
@@ -19,6 +19,7 @@ const selectedStationId = ref(null);
 const mileage = ref('');
 const litres = ref('');
 const cost = ref('');
+const filledAt = ref(new Date().toISOString().slice(0, 16));
 const error = ref('');
 const loading = ref(false);
 const showDropdown = ref(false);
@@ -61,7 +62,8 @@ async function handleSubmit() {
       mileageVal,
       litresVal,
       costVal,
-      token.value
+      token.value,
+      filledAt.value ? new Date(filledAt.value).toISOString() : null
     );
     selectedVehicleId.value = '';
     mileage.value = '';
@@ -69,6 +71,7 @@ async function handleSubmit() {
     cost.value = '';
     stationQuery.value = '';
     selectedStationId.value = null;
+    filledAt.value = new Date().toISOString().slice(0, 16);
     emit('success');
   } catch (e) {
     error.value = e.message;
@@ -124,6 +127,10 @@ function hideDropdown() {
     <label>
       <span>Cost</span>
       <input type="number" step="0.01" v-model="cost" placeholder="Total cost" :disabled="loading" />
+    </label>
+    <label>
+      <span>Date/Time (optional)</span>
+      <input type="datetime-local" v-model="filledAt" :disabled="loading" />
     </label>
     <button type="submit" :disabled="loading">
       {{ loading ? 'Saving...' : 'Add Entry' }}

--- a/frontend/src/composables/useAuth.js
+++ b/frontend/src/composables/useAuth.js
@@ -1,4 +1,5 @@
 import { ref, computed } from 'vue';
+import router from '../router';
 
 const user = ref(getStoredAuth());
 
@@ -38,6 +39,16 @@ export function useAuth() {
     const redirectUserId = params.get('user_id');
     const redirectEmail = params.get('email');
 
+    // Check if these exact params were already processed (prevents re-login on refresh after logout)
+    const processedToken = sessionStorage.getItem('oauth_processed_token');
+    if (processedToken && processedToken === redirectToken) {
+      // Already processed these params, clean URL if needed and return
+      if (redirectToken) {
+        router.replace({ path: '/', query: {} });
+      }
+      return;
+    }
+
     if (redirectToken && redirectUserId && redirectEmail) {
       const auth = {
         token: redirectToken,
@@ -46,14 +57,23 @@ export function useAuth() {
       };
       user.value = { token: auth.token, userId: auth.user_id, email: auth.email };
       storeAuth(auth);
-      // Remove token from URL to prevent reuse on refresh
-      window.history.replaceState({}, '', '/');
+      // Mark these params as processed
+      sessionStorage.setItem('oauth_processed_token', redirectToken);
+      // Remove token from URL to prevent reuse on refresh - use router.replace for proper cleanup
+      router.replace({ path: '/', query: {} });
     }
   }
 
   function logout() {
     user.value = null;
     clearAuth();
+    // Clear the processed token flag so a fresh login will work
+    sessionStorage.removeItem('oauth_processed_token');
+    // Clean URL of any token params that might be present
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('token')) {
+      router.replace({ path: '/', query: {} });
+    }
   }
 
   return {

--- a/frontend/src/services/fuelEntries.js
+++ b/frontend/src/services/fuelEntries.js
@@ -8,14 +8,14 @@ export async function listRecentFuelEntries(userId, token, limit = 10) {
   return apiGet(`/fuel-entries?user_id=${userId}&limit=${limit}`, token);
 }
 
-export async function createFuelEntry(vehicleId, stationId, mileage, litres, cost, token) {
+export async function createFuelEntry(vehicleId, stationId, mileage, litres, cost, token, filledAt = null) {
   return apiPost('/fuel-entries', {
     vehicle_id: vehicleId,
     station_id: stationId,
     mileage_km: mileage,
     litres,
     cost,
-    filled_at: null,
+    filled_at: filledAt,
   }, token);
 }
 

--- a/frontend/src/services/version.js
+++ b/frontend/src/services/version.js
@@ -1,0 +1,7 @@
+export async function getVersion() {
+  const response = await fetch('/api/version');
+  if (!response.ok) {
+    throw new Error('Failed to fetch version');
+  }
+  return response.json();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,11 @@ async fn serve_openapi() -> axum::response::Json<String> {
     axum::response::Json(api_doc::ApiDoc::openapi().to_json().unwrap())
 }
 
+async fn serve_version() -> axum::response::Json<serde_json::Value> {
+    const VERSION: &str = env!("CARGO_PKG_VERSION");
+    axum::response::Json(serde_json::json!({ "version": VERSION }))
+}
+
 async fn serve_index() -> impl axum::response::IntoResponse {
     axum::response::Html(include_str!("pkg/index.html"))
 }
@@ -101,6 +106,7 @@ async fn main() {
     };
 
     let mut app = Router::new()
+        .route("/api/version", get(serve_version))
         .route("/api/openapi.json", get(serve_openapi))
         .merge(oauth_handlers::router())
         .merge(user_handlers::router())

--- a/src/pkg/index.html
+++ b/src/pkg/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Deesl Fuel Tracker</title>
-    <script type="module" crossorigin src="/assets/index-CFHP3wPQ.js"></script>
+    <script type="module" crossorigin src="/assets/index-DYobBiHa.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-Dp3x3Pff.css">
   </head>
   <body>

--- a/src/pkg/index.html
+++ b/src/pkg/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Deesl Fuel Tracker</title>
-    <script type="module" crossorigin src="/assets/index-DYobBiHa.js"></script>
+    <script type="module" crossorigin src="/assets/index-b3WFvxkO.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-Dp3x3Pff.css">
   </head>
   <body>

--- a/src/pkg/index.html
+++ b/src/pkg/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Deesl Fuel Tracker</title>
-    <script type="module" crossorigin src="/assets/index-Dn-2IZ1V.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BqUXdN2p.css">
+    <script type="module" crossorigin src="/assets/index-CFHP3wPQ.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-Dp3x3Pff.css">
   </head>
   <body>
     <div id="app"></div>

--- a/src/vehicle_fuel_handlers.rs
+++ b/src/vehicle_fuel_handlers.rs
@@ -443,7 +443,7 @@ pub struct CreateFuelEntryRequest {
     pub mileage_km: i32,
     pub litres: f64,
     pub cost: f64,
-    pub filled_at: Option<chrono::NaiveDateTime>,
+    pub filled_at: Option<String>,
 }
 
 pub async fn create_fuel_entry(
@@ -457,7 +457,24 @@ pub async fn create_fuel_entry(
     let mileage_km = payload.mileage_km;
     let litres = payload.litres;
     let cost = payload.cost;
-    let filled_at = payload.filled_at;
+    
+    // Parse ISO 8601 datetime string into NaiveDateTime
+    let filled_at: Option<chrono::NaiveDateTime> = match payload.filled_at {
+        Some(ref dt_str) if !dt_str.is_empty() => {
+            // Try to parse as DateTime<Utc> (with timezone) first, then convert to naive
+            dt_str.parse::<chrono::DateTime<chrono::Utc>>()
+                .map(|dt| dt.naive_utc())
+                .or_else(|_| {
+                    // Fall back to parsing as NaiveDateTime directly
+                    dt_str.parse::<chrono::NaiveDateTime>()
+                })
+                .map_err(|_| {
+                    (StatusCode::BAD_REQUEST, format!("Invalid datetime format: {}", dt_str))
+                })?
+                .into()
+        }
+        _ => None,
+    };
 
     let (entry, vehicle): (FuelEntry, Vehicle) = conn
         .interact(move |conn| {

--- a/src/vehicle_fuel_handlers.rs
+++ b/src/vehicle_fuel_handlers.rs
@@ -457,19 +457,23 @@ pub async fn create_fuel_entry(
     let mileage_km = payload.mileage_km;
     let litres = payload.litres;
     let cost = payload.cost;
-    
+
     // Parse ISO 8601 datetime string into NaiveDateTime
     let filled_at: Option<chrono::NaiveDateTime> = match payload.filled_at {
         Some(ref dt_str) if !dt_str.is_empty() => {
             // Try to parse as DateTime<Utc> (with timezone) first, then convert to naive
-            dt_str.parse::<chrono::DateTime<chrono::Utc>>()
+            dt_str
+                .parse::<chrono::DateTime<chrono::Utc>>()
                 .map(|dt| dt.naive_utc())
                 .or_else(|_| {
                     // Fall back to parsing as NaiveDateTime directly
                     dt_str.parse::<chrono::NaiveDateTime>()
                 })
                 .map_err(|_| {
-                    (StatusCode::BAD_REQUEST, format!("Invalid datetime format: {}", dt_str))
+                    (
+                        StatusCode::BAD_REQUEST,
+                        format!("Invalid datetime format: {}", dt_str),
+                    )
                 })?
                 .into()
         }


### PR DESCRIPTION
## Summary

This PR addresses all 4 frontend TODOs from TODOS.md:

### Changes

1. **Fix logout/URL token issue** (useAuth.js)
   - Track processed OAuth tokens in sessionStorage to prevent re-login on refresh after logout
   - Use Vue Router's `replace()` instead of `window.history.replaceState()` for proper URL cleanup
   - Clear processed token flag and clean URL on logout

2. **Add version footer** (main.rs, AppFooter.vue, version.js)
   - New `/api/version` endpoint returning backend version from Cargo.toml
   - New `AppFooter` component that displays version in subtle footer
   - Vite already provides cache busting via content-hashed asset filenames

3. **Last-used vehicle default** (Dashboard.vue, QuickAddFuelForm.vue)
   - QuickAddFuelForm now defaults to vehicle from most recent fuel entry
   - Falls back to first vehicle if no entries exist yet
   - Determined from recent entries data (no separate storage needed)

4. **Datetime picker for back-dating** (QuickAddFuelForm.vue, AddFuelEntryForm.vue, vehicle_fuel_handlers.rs)
   - Both fuel entry forms have optional datetime-local input
   - Defaults to current datetime
   - Backend now accepts standard ISO 8601 datetime strings with proper parsing

### Testing
- Build passes: `cargo build` and `npm run build` both succeed
- Frontend datetime picker correctly sends ISO format dates
- Backend properly parses both with and without timezone formats