### PR TITLE
Add vehicle sharing with JWT authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "headers",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "serde_core",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,14 +425,16 @@ dependencies = [
 
 [[package]]
 name = "deesl"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "askama",
  "axum",
+ "axum-extra",
  "chrono",
  "deadpool-diesel",
  "diesel",
  "dotenvy",
+ "headers",
  "http-security-headers",
  "jsonwebtoken",
  "oauth2",
@@ -727,6 +752,30 @@ name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core",
+ "http 1.3.1",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.3.1",
+]
 
 [[package]]
 name = "heck"
@@ -1998,6 +2047,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,17 @@
 [package]
 name = "deesl"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 
 [dependencies]
 askama = "0.12.1"
 axum = { version = "0.8.1", features = ["json", "tokio", "form"] }
+axum-extra = { version = "0.10", features = ["typed-header"] }
 chrono = { version = "0.4.40", features = ["serde"] }
 deadpool-diesel = { version = "0.6.1", features = ["postgres"] }
 diesel = { version = "2.2.8", features = ["postgres", "chrono"] }
 dotenvy = "0.15.7"
+headers = "0.4"
 jsonwebtoken = "9.3"
 rstest = "0.25.0"
 serde = { version = "1.0.219", features = ["derive"] }

--- a/TODOS.md
+++ b/TODOS.md
@@ -4,5 +4,7 @@
 - [x] Frontend: Add cache busting for assets, and include version in UI somewhere subtle
 - [x] Frontend: Populate last-used vehicle by default for fuel entries
 - [x] Frontend: Add date and time picker for fuel transactions so they can be back-dated
+- [x] Vehicle sharing with other users (with read/write permission levels)
+- [ ] Security: Should the frontend be using query params? JWTs were intended
+- [ ] Backend: Add better integration tests using proper tokens and checking permissions
 - [ ] Add bulk transaction import from file
-- [ ] Vehicle sharing with other users (with read/write permission levels)

--- a/frontend/src/components/AddVehicleForm.vue
+++ b/frontend/src/components/AddVehicleForm.vue
@@ -5,7 +5,7 @@ import { useAuth } from '../composables/useAuth';
 
 const emit = defineEmits(['success']);
 
-const { token, userId } = useAuth();
+const { token } = useAuth();
 
 const make = ref('');
 const model = ref('');
@@ -23,7 +23,7 @@ async function handleSubmit() {
   error.value = '';
 
   try {
-    await createVehicle(make.value, model.value, registration.value, userId.value, token.value);
+    await createVehicle(make.value, model.value, registration.value, token.value);
     make.value = '';
     model.value = '';
     registration.value = '';

--- a/frontend/src/components/Dashboard.vue
+++ b/frontend/src/components/Dashboard.vue
@@ -6,7 +6,7 @@ import { listFuelStations, listRecentFuelEntries } from '../services/fuelEntries
 import FuelEntryItem from './FuelEntryItem.vue';
 import QuickAddFuelForm from './QuickAddFuelForm.vue';
 
-const { token, userId } = useAuth();
+const { token } = useAuth();
 
 const vehicles = ref([]);
 const stations = ref([]);
@@ -23,9 +23,9 @@ const lastUsedVehicleId = computed(() => {
 async function loadData() {
   try {
     const [v, s, entries] = await Promise.all([
-      listVehicles(userId.value, token.value),
+      listVehicles(token.value),
       listFuelStations(token.value),
-      listRecentFuelEntries(userId.value, token.value),
+      listRecentFuelEntries(token.value),
     ]);
     vehicles.value = v;
     stations.value = s;
@@ -38,9 +38,9 @@ async function loadData() {
 }
 
 async function loadRecentEntries() {
-  if (!userId.value) return;
+  if (!token.value) return;
   try {
-    recentEntries.value = await listRecentFuelEntries(userId.value, token.value);
+    recentEntries.value = await listRecentFuelEntries(token.value);
   } catch (e) {
     console.error('Failed to load recent entries:', e);
   }

--- a/frontend/src/components/VehicleItem.vue
+++ b/frontend/src/components/VehicleItem.vue
@@ -1,17 +1,23 @@
 <script setup>
 import { ref } from 'vue';
 import { deleteVehicle } from '../services/vehicles';
+import { shareVehicle } from '../services/vehicleShares';
 import { useAuth } from '../composables/useAuth';
 
 const props = defineProps({
   vehicle: Object,
 });
 
-const emit = defineEmits(['delete', 'select']);
+const emit = defineEmits(['delete', 'select', 'share']);
 
 const { token } = useAuth();
 const showConfirm = ref(false);
 const deleting = ref(false);
+const showShareForm = ref(false);
+const shareEmail = ref('');
+const sharePermission = ref('read');
+const shareLoading = ref(false);
+const shareError = ref('');
 
 async function handleDelete() {
   deleting.value = true;
@@ -22,23 +28,165 @@ async function handleDelete() {
     console.error(e);
   }
 }
+
+async function handleShare() {
+  if (!shareEmail.value) {
+    shareError.value = 'Please enter an email address';
+    return;
+  }
+
+  shareLoading.value = true;
+  shareError.value = '';
+
+  try {
+    await shareVehicle(props.vehicle.id, shareEmail.value, sharePermission.value, token.value);
+    shareEmail.value = '';
+    sharePermission.value = 'read';
+    showShareForm.value = false;
+    emit('share');
+  } catch (e) {
+    shareError.value = e.message;
+  } finally {
+    shareLoading.value = false;
+  }
+}
+
+function getPermissionBadgeClass() {
+  if (props.vehicle.permission_level === 'owner') return 'badge-owner';
+  if (props.vehicle.permission_level === 'write') return 'badge-write';
+  return 'badge-read';
+}
+
+function getPermissionLabel() {
+  if (props.vehicle.permission_level === 'owner') return 'Owner';
+  if (props.vehicle.permission_level === 'write') return 'Can Write';
+  return 'Read Only';
+}
 </script>
 
 <template>
   <li class="vehicle-item">
     <div class="vehicle-info" @click="emit('select', vehicle)">
-      <strong>{{ vehicle.make }} {{ vehicle.model }}</strong>
+      <div class="vehicle-header">
+        <strong>{{ vehicle.make }} {{ vehicle.model }}</strong>
+        <span :class="['permission-badge', getPermissionBadgeClass()]">
+          {{ getPermissionLabel() }}
+        </span>
+      </div>
       <span class="registration">{{ vehicle.registration }}</span>
     </div>
     <div class="vehicle-actions">
-      <template v-if="showConfirm">
-        <span>Confirm? </span>
-        <button @click="handleDelete" :disabled="deleting">
-          {{ deleting ? 'Deleting...' : 'Yes' }}
-        </button>
-        <button @click="showConfirm = false" :disabled="deleting">No</button>
+      <template v-if="!vehicle.is_shared">
+        <button v-if="!showShareForm" @click="showShareForm = true">Share</button>
+        <template v-else>
+          <div class="share-form">
+            <input 
+              type="email" 
+              v-model="shareEmail" 
+              placeholder="Enter email"
+              :disabled="shareLoading"
+            />
+            <select v-model="sharePermission" :disabled="shareLoading">
+              <option value="read">Read</option>
+              <option value="write">Write</option>
+            </select>
+            <button @click="handleShare" :disabled="shareLoading">
+              {{ shareLoading ? 'Sharing...' : 'Share' }}
+            </button>
+            <button @click="showShareForm = false" :disabled="shareLoading">Cancel</button>
+            <p v-if="shareError" class="error">{{ shareError }}</p>
+          </div>
+        </template>
       </template>
-      <button v-else class="delete-btn" @click="showConfirm = true">Delete</button>
+      
+      <template v-if="!vehicle.is_shared && !showShareForm">
+        <template v-if="showConfirm">
+          <span>Confirm? </span>
+          <button @click="handleDelete" :disabled="deleting">
+            {{ deleting ? 'Deleting...' : 'Yes' }}
+          </button>
+          <button @click="showConfirm = false" :disabled="deleting">No</button>
+        </template>
+        <button v-else class="delete-btn" @click="showConfirm = true">Delete</button>
+      </template>
     </div>
   </li>
 </template>
+
+<style scoped>
+.vehicle-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 1rem;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.vehicle-info {
+  flex: 1;
+  cursor: pointer;
+}
+
+.vehicle-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.permission-badge {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 3px;
+  font-weight: 500;
+}
+
+.badge-owner {
+  background-color: #4CAF50;
+  color: white;
+}
+
+.badge-write {
+  background-color: #2196F3;
+  color: white;
+}
+
+.badge-read {
+  background-color: #9E9E9E;
+  color: white;
+}
+
+.registration {
+  color: #666;
+  font-size: 0.9rem;
+  margin-left: 0.5rem;
+}
+
+.vehicle-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.share-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.share-form input,
+.share-form select {
+  padding: 0.25rem;
+  font-size: 0.9rem;
+}
+
+.delete-btn {
+  background-color: #f44336;
+  color: white;
+}
+
+.error {
+  color: #f44336;
+  font-size: 0.8rem;
+  margin: 0;
+}
+</style>

--- a/frontend/src/components/VehiclesPage.vue
+++ b/frontend/src/components/VehiclesPage.vue
@@ -7,7 +7,7 @@ import VehicleItem from './VehicleItem.vue';
 import AddVehicleForm from './AddVehicleForm.vue';
 import FuelEntrySection from './FuelEntrySection.vue';
 
-const { token, userId } = useAuth();
+const { token } = useAuth();
 
 const vehicles = ref([]);
 const stations = ref([]);
@@ -19,7 +19,7 @@ const selectedVehicle = ref(null);
 async function loadData() {
   try {
     const [v, s] = await Promise.all([
-      listVehicles(userId.value, token.value),
+      listVehicles(token.value),
       listFuelStations(token.value),
     ]);
     vehicles.value = v;
@@ -60,6 +60,7 @@ onMounted(loadData);
             :vehicle="vehicle"
             @delete="loadData"
             @select="selectedVehicle = $event"
+            @share="loadData"
           />
         </ul>
 

--- a/frontend/src/services/fuelEntries.js
+++ b/frontend/src/services/fuelEntries.js
@@ -4,8 +4,8 @@ export async function listFuelEntries(vehicleId, token) {
   return apiGet(`/fuel-entries?vehicle_id=${vehicleId}`, token);
 }
 
-export async function listRecentFuelEntries(userId, token, limit = 10) {
-  return apiGet(`/fuel-entries?user_id=${userId}&limit=${limit}`, token);
+export async function listRecentFuelEntries(token, limit = 10) {
+  return apiGet(`/fuel-entries?limit=${limit}`, token);
 }
 
 export async function createFuelEntry(vehicleId, stationId, mileage, litres, cost, token, filledAt = null) {

--- a/frontend/src/services/vehicleShares.js
+++ b/frontend/src/services/vehicleShares.js
@@ -1,0 +1,17 @@
+import { apiGet, apiPost, apiDelete } from './api';
+
+export async function listVehicleShares(token) {
+  return apiGet('/vehicle-shares', token);
+}
+
+export async function shareVehicle(vehicleId, sharedWithEmail, permissionLevel, token) {
+  return apiPost('/vehicle-shares', { 
+    vehicle_id: vehicleId, 
+    shared_with_email: sharedWithEmail, 
+    permission_level: permissionLevel 
+  }, token);
+}
+
+export async function unshareVehicle(shareId, token) {
+  return apiDelete(`/vehicle-shares/${shareId}`, token);
+}

--- a/frontend/src/services/vehicles.js
+++ b/frontend/src/services/vehicles.js
@@ -1,11 +1,11 @@
 import { apiGet, apiPost, apiDelete } from './api';
 
-export async function listVehicles(userId, token) {
-  return apiGet(`/vehicles?user_id=${userId}`, token);
+export async function listVehicles(token) {
+  return apiGet('/vehicles', token);
 }
 
-export async function createVehicle(make, model, registration, userId, token) {
-  return apiPost('/vehicles', { make, model, registration, owner_id: userId }, token);
+export async function createVehicle(make, model, registration, token) {
+  return apiPost('/vehicles', { make, model, registration }, token);
 }
 
 export async function deleteVehicle(vehicleId, token) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod schema;
 mod state;
 mod user_handlers;
 mod vehicle_fuel_handlers;
+mod vehicle_share_handlers;
 
 pub use state::AppState;
 
@@ -111,6 +112,7 @@ async fn main() {
         .merge(oauth_handlers::router())
         .merge(user_handlers::router())
         .merge(vehicle_fuel_handlers::router())
+        .merge(vehicle_share_handlers::router())
         .nest_service("/assets", ServeDir::new("src/pkg/assets"))
         .fallback(serve_index)
         .layer(TraceLayer::new_for_http())

--- a/src/pkg/index.html
+++ b/src/pkg/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Deesl Fuel Tracker</title>
-    <script type="module" crossorigin src="/assets/index-b3WFvxkO.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-Dp3x3Pff.css">
+    <script type="module" crossorigin src="/assets/index-oSifVYQ6.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-CSLLUigs.css">
   </head>
   <body>
     <div id="app"></div>

--- a/src/vehicle_fuel_handlers.rs
+++ b/src/vehicle_fuel_handlers.rs
@@ -5,14 +5,40 @@ use axum::{
     response::IntoResponse,
     routing::{delete, get},
 };
+use axum_extra::{
+    TypedHeader,
+    headers::{Authorization, authorization::Bearer},
+};
 use deadpool_diesel::postgres::Pool;
 use diesel::prelude::*;
 use serde::Deserialize;
 
 use crate::AppState;
+use crate::auth::AuthConfig;
 use crate::handlers::internal_error;
 use crate::models::{FuelEntry, FuelStation, NewFuelEntry, NewFuelStation, NewVehicle, Vehicle};
-use crate::schema::{fuel_entries, fuel_stations, vehicles};
+use crate::schema::{fuel_entries, fuel_stations, vehicle_shares, vehicles};
+
+#[derive(Debug, Clone)]
+pub struct AuthUser {
+    pub user_id: i32,
+    #[allow(dead_code)]
+    pub email: String,
+}
+
+fn extract_auth_user(
+    TypedHeader(Authorization(bearer)): TypedHeader<Authorization<Bearer>>,
+) -> Result<AuthUser, (StatusCode, String)> {
+    let auth_config = AuthConfig::new();
+    let claims = auth_config
+        .validate_token(bearer.token())
+        .map_err(|_| (StatusCode::UNAUTHORIZED, "Invalid token".to_string()))?;
+
+    Ok(AuthUser {
+        user_id: claims.user_id,
+        email: claims.sub,
+    })
+}
 
 pub fn router() -> Router<AppState> {
     Router::new()
@@ -132,32 +158,38 @@ pub struct VehicleResponse {
     pub make: String,
     pub model: String,
     pub registration: String,
+    pub is_shared: bool,
+    pub permission_level: Option<String>,
 }
 
-impl From<Vehicle> for VehicleResponse {
-    fn from(v: Vehicle) -> Self {
+impl VehicleResponse {
+    fn from_vehicle(vehicle: Vehicle, is_shared: bool, permission_level: Option<String>) -> Self {
         Self {
-            id: v.id,
-            make: v.make,
-            model: v.model,
-            registration: v.registration,
+            id: vehicle.id,
+            make: vehicle.make,
+            model: vehicle.model,
+            registration: vehicle.registration,
+            is_shared,
+            permission_level,
         }
     }
 }
 
 pub async fn list_vehicles(
     State(pool): State<Pool>,
-    axum::extract::Query(params): axum::extract::Query<VehicleQueryParams>,
+    auth_header: TypedHeader<Authorization<Bearer>>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let auth_user = extract_auth_user(auth_header)?;
     let conn = pool.get().await.map_err(internal_error)?;
+    let user_id = auth_user.user_id;
 
-    let vehicles: Vec<Vehicle> = conn
+    // Get owned vehicles
+    let owned_vehicles: Vec<Vehicle> = conn
         .interact(move |conn| {
-            let mut query = vehicles::table.into_boxed();
-            if let Some(user_id) = params.user_id {
-                query = query.filter(vehicles::owner_id.eq(user_id));
-            }
-            query.load(conn)
+            vehicles::table
+                .filter(vehicles::owner_id.eq(user_id))
+                .order(vehicles::registration)
+                .load(conn)
         })
         .await
         .map_err(internal_error)?
@@ -168,17 +200,46 @@ pub async fn list_vehicles(
             )
         })?;
 
-    Ok(Json(
-        vehicles
-            .into_iter()
-            .map(VehicleResponse::from)
-            .collect::<Vec<_>>(),
-    ))
-}
+    // Get shared vehicles
+    let shared_vehicles: Vec<(Vehicle, String)> = conn
+        .interact(move |conn| {
+            vehicle_shares::table
+                .inner_join(vehicles::table)
+                .filter(vehicle_shares::shared_with_user_id.eq(user_id))
+                .select((Vehicle::as_select(), vehicle_shares::permission_level))
+                .order(vehicles::registration)
+                .load(conn)
+        })
+        .await
+        .map_err(internal_error)?
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("DB error: {}", e),
+            )
+        })?;
 
-#[derive(Deserialize)]
-pub struct VehicleQueryParams {
-    pub user_id: Option<i32>,
+    let mut response: Vec<VehicleResponse> = Vec::new();
+
+    // Add owned vehicles
+    for vehicle in owned_vehicles {
+        response.push(VehicleResponse::from_vehicle(
+            vehicle,
+            false,
+            Some("owner".to_string()),
+        ));
+    }
+
+    // Add shared vehicles
+    for (vehicle, permission_level) in shared_vehicles {
+        response.push(VehicleResponse::from_vehicle(
+            vehicle,
+            true,
+            Some(permission_level),
+        ));
+    }
+
+    Ok(Json(response))
 }
 
 #[derive(Deserialize)]
@@ -186,19 +247,20 @@ pub struct CreateVehicleRequest {
     pub make: String,
     pub model: String,
     pub registration: String,
-    pub owner_id: i32,
 }
 
 pub async fn create_vehicle(
     State(pool): State<Pool>,
+    auth_header: TypedHeader<Authorization<Bearer>>,
     Json(payload): Json<CreateVehicleRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let auth_user = extract_auth_user(auth_header)?;
     let conn = pool.get().await.map_err(internal_error)?;
 
     let make = payload.make.clone();
     let model = payload.model.clone();
     let registration = payload.registration.clone();
-    let owner_id = payload.owner_id;
+    let owner_id = auth_user.user_id;
 
     let vehicle: Vehicle = conn
         .interact(move |conn| {
@@ -221,86 +283,51 @@ pub async fn create_vehicle(
             )
         })?;
 
-    Ok((StatusCode::CREATED, Json(VehicleResponse::from(vehicle))))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::models::{FuelStation, Vehicle};
-    use chrono::NaiveDateTime;
-
-    fn epoch() -> NaiveDateTime {
-        chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc()
-    }
-
-    fn make_vehicle(id: i32, make: &str, model: &str, registration: &str) -> Vehicle {
-        Vehicle {
-            id,
-            make: make.to_string(),
-            model: model.to_string(),
-            registration: registration.to_string(),
-            created: epoch(),
-            owner_id: 1,
-        }
-    }
-
-    fn make_station(id: i32, name: &str) -> FuelStation {
-        FuelStation {
-            id,
-            name: name.to_string(),
-            created_at: epoch(),
-        }
-    }
-
-    // --- FuelStationResponse::from ---
-
-    #[test]
-    fn test_fuel_station_response_maps_id_and_name() {
-        let station = make_station(5, "Shell Grafton Street");
-        let response = FuelStationResponse::from(station);
-        assert_eq!(response.id, 5);
-        assert_eq!(response.name, "Shell Grafton Street");
-    }
-
-    #[test]
-    fn test_fuel_station_response_does_not_include_created_at() {
-        // Compile-time guarantee: FuelStationResponse only has id + name
-        let station = make_station(1, "BP");
-        let response = FuelStationResponse::from(station);
-        let _ = response.id;
-        let _ = response.name;
-    }
-
-    // --- VehicleResponse::from ---
-
-    #[test]
-    fn test_vehicle_response_maps_all_fields() {
-        let vehicle = make_vehicle(3, "Toyota", "Corolla", "241-D-12345");
-        let response = VehicleResponse::from(vehicle);
-        assert_eq!(response.id, 3);
-        assert_eq!(response.make, "Toyota");
-        assert_eq!(response.model, "Corolla");
-        assert_eq!(response.registration, "241-D-12345");
-    }
-
-    #[test]
-    fn test_vehicle_response_does_not_include_owner_id_or_created() {
-        // VehicleResponse only exposes id, make, model, registration
-        let vehicle = make_vehicle(99, "Ford", "Focus", "222-G-9999");
-        let response = VehicleResponse::from(vehicle);
-        let _ = response.id;
-        let _ = response.make;
-        let _ = response.model;
-        let _ = response.registration;
-    }
+    Ok((
+        StatusCode::CREATED,
+        Json(VehicleResponse::from_vehicle(
+            vehicle,
+            false,
+            Some("owner".to_string()),
+        )),
+    ))
 }
 
 pub async fn delete_vehicle(
     State(pool): State<Pool>,
+    auth_header: TypedHeader<Authorization<Bearer>>,
     axum::extract::Path(id): axum::extract::Path<i32>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let auth_user = extract_auth_user(auth_header)?;
     let conn = pool.get().await.map_err(internal_error)?;
+    let user_id = auth_user.user_id;
+
+    // Check ownership before deleting
+    let is_owner: bool = conn
+        .interact(move |conn| {
+            vehicles::table
+                .filter(vehicles::id.eq(id))
+                .filter(vehicles::owner_id.eq(user_id))
+                .first::<Vehicle>(conn)
+                .optional()
+        })
+        .await
+        .map_err(internal_error)?
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("DB error: {}", e),
+            )
+        })?
+        .map(|_| true)
+        .unwrap_or(false);
+
+    if !is_owner {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "You don't own this vehicle".to_string(),
+        ));
+    }
 
     conn.interact(move |conn| {
         diesel::delete(vehicles::table.filter(vehicles::id.eq(id))).execute(conn)
@@ -334,9 +361,12 @@ pub struct FuelEntryResponse {
 
 pub async fn list_fuel_entries(
     State(pool): State<Pool>,
+    auth_header: TypedHeader<Authorization<Bearer>>,
     axum::extract::Query(params): axum::extract::Query<FuelEntryQueryParams>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let auth_user = extract_auth_user(auth_header)?;
     let conn = pool.get().await.map_err(internal_error)?;
+    let user_id = auth_user.user_id;
 
     let entries: Vec<(FuelEntry, Option<String>, String, String, String)> = conn
         .interact(move |conn| {
@@ -349,9 +379,14 @@ pub async fn list_fuel_entries(
                 query = query.filter(fuel_entries::vehicle_id.eq(vehicle_id));
             }
 
-            if let Some(user_id) = params.user_id {
-                query = query.filter(vehicles::owner_id.eq(user_id));
-            }
+            // Filter for owned vehicles OR vehicles shared with user
+            query = query.filter(
+                vehicles::owner_id.eq(user_id).or(vehicles::id.eq_any(
+                    vehicle_shares::table
+                        .filter(vehicle_shares::shared_with_user_id.eq(user_id))
+                        .select(vehicle_shares::vehicle_id),
+                )),
+            );
 
             query
                 .select((
@@ -400,14 +435,16 @@ pub async fn list_fuel_entries(
 #[derive(Deserialize)]
 pub struct FuelEntryQueryParams {
     pub vehicle_id: Option<i32>,
-    pub user_id: Option<i32>,
 }
 
 pub async fn get_fuel_entry(
     State(pool): State<Pool>,
+    auth_header: TypedHeader<Authorization<Bearer>>,
     axum::extract::Path(id): axum::extract::Path<i32>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let auth_user = extract_auth_user(auth_header)?;
     let conn = pool.get().await.map_err(internal_error)?;
+    let user_id = auth_user.user_id;
 
     let (entry, vehicle): (FuelEntry, Vehicle) = conn
         .interact(move |conn| {
@@ -420,6 +457,34 @@ pub async fn get_fuel_entry(
         .await
         .map_err(internal_error)?
         .map_err(|_| (StatusCode::NOT_FOUND, "Fuel entry not found".to_string()))?;
+
+    // Check if user has access to this vehicle
+    let has_access = conn
+        .interact(move |conn| {
+            // Check ownership
+            if vehicle.owner_id == user_id {
+                return Ok::<bool, diesel::result::Error>(true);
+            }
+            // Check if shared
+            let share_exists = vehicle_shares::table
+                .filter(vehicle_shares::vehicle_id.eq(vehicle.id))
+                .filter(vehicle_shares::shared_with_user_id.eq(user_id))
+                .first::<crate::models::VehicleShare>(conn)
+                .optional()?;
+            Ok(share_exists.is_some())
+        })
+        .await
+        .map_err(internal_error)?
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("DB error: {}", e),
+            )
+        })?;
+
+    if !has_access {
+        return Err((StatusCode::FORBIDDEN, "Access denied".to_string()));
+    }
 
     Ok(Json(FuelEntryResponse {
         id: entry.id,
@@ -448,11 +513,59 @@ pub struct CreateFuelEntryRequest {
 
 pub async fn create_fuel_entry(
     State(pool): State<Pool>,
+    auth_header: TypedHeader<Authorization<Bearer>>,
     Json(payload): Json<CreateFuelEntryRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let auth_user = extract_auth_user(auth_header)?;
     let conn = pool.get().await.map_err(internal_error)?;
+    let user_id = auth_user.user_id;
 
     let vehicle_id = payload.vehicle_id;
+
+    // Check if user has write access to this vehicle
+    let has_write_access: (bool, bool) = conn
+        .interact(move |conn| {
+            let vehicle: Vehicle = vehicles::table
+                .filter(vehicles::id.eq(vehicle_id))
+                .first(conn)?;
+
+            // Check ownership
+            if vehicle.owner_id == user_id {
+                return Ok::<(bool, bool), diesel::result::Error>((true, true));
+            }
+
+            // Check if shared with write permission
+            let share = vehicle_shares::table
+                .filter(vehicle_shares::vehicle_id.eq(vehicle_id))
+                .filter(vehicle_shares::shared_with_user_id.eq(user_id))
+                .first::<crate::models::VehicleShare>(conn)
+                .optional()?;
+
+            match share {
+                Some(s) => Ok((true, s.permission_level == "write")),
+                None => Ok((false, false)),
+            }
+        })
+        .await
+        .map_err(internal_error)?
+        .map_err(|_| (StatusCode::NOT_FOUND, "Vehicle not found".to_string()))?;
+
+    let (has_access, has_write) = has_write_access;
+
+    if !has_access {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "You don't have access to this vehicle".to_string(),
+        ));
+    }
+
+    if !has_write {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "You don't have write permission for this vehicle".to_string(),
+        ));
+    }
+
     let station_id = payload.station_id;
     let mileage_km = payload.mileage_km;
     let litres = payload.litres;
@@ -529,9 +642,55 @@ pub async fn create_fuel_entry(
 
 pub async fn delete_fuel_entry(
     State(pool): State<Pool>,
+    auth_header: TypedHeader<Authorization<Bearer>>,
     axum::extract::Path(id): axum::extract::Path<i32>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let auth_user = extract_auth_user(auth_header)?;
     let conn = pool.get().await.map_err(internal_error)?;
+    let user_id = auth_user.user_id;
+
+    // Check if user has write access to this vehicle
+    let has_write_access = conn
+        .interact(move |conn| {
+            let entry: FuelEntry = fuel_entries::table
+                .filter(fuel_entries::id.eq(id))
+                .first(conn)
+                .map_err(|_| diesel::result::Error::NotFound)?;
+
+            let vehicle: Vehicle = vehicles::table
+                .filter(vehicles::id.eq(entry.vehicle_id))
+                .first(conn)?;
+
+            // Check ownership
+            if vehicle.owner_id == user_id {
+                return Ok::<bool, diesel::result::Error>(true);
+            }
+
+            // Check if shared with write permission
+            let share = vehicle_shares::table
+                .filter(vehicle_shares::vehicle_id.eq(vehicle.id))
+                .filter(vehicle_shares::shared_with_user_id.eq(user_id))
+                .first::<crate::models::VehicleShare>(conn)
+                .optional()?;
+
+            match share {
+                Some(s) => Ok(s.permission_level == "write"),
+                None => Ok(false),
+            }
+        })
+        .await
+        .map_err(internal_error)?;
+
+    match has_write_access {
+        Ok(false) => {
+            return Err((
+                StatusCode::FORBIDDEN,
+                "You don't have write permission to delete this entry".to_string(),
+            ));
+        }
+        Err(_) => return Err((StatusCode::NOT_FOUND, "Fuel entry not found".to_string())),
+        Ok(true) => {}
+    }
 
     conn.interact(move |conn| {
         diesel::delete(fuel_entries::table.filter(fuel_entries::id.eq(id))).execute(conn)
@@ -546,4 +705,75 @@ pub async fn delete_fuel_entry(
     })?;
 
     Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{FuelStation, Vehicle};
+    use chrono::NaiveDateTime;
+
+    fn epoch() -> NaiveDateTime {
+        chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc()
+    }
+
+    fn make_vehicle(id: i32, make: &str, model: &str, registration: &str) -> Vehicle {
+        Vehicle {
+            id,
+            make: make.to_string(),
+            model: model.to_string(),
+            registration: registration.to_string(),
+            created: epoch(),
+            owner_id: 1,
+        }
+    }
+
+    fn make_station(id: i32, name: &str) -> FuelStation {
+        FuelStation {
+            id,
+            name: name.to_string(),
+            created_at: epoch(),
+        }
+    }
+
+    // --- FuelStationResponse::from ---
+
+    #[test]
+    fn test_fuel_station_response_maps_id_and_name() {
+        let station = make_station(5, "Shell Grafton Street");
+        let response = FuelStationResponse::from(station);
+        assert_eq!(response.id, 5);
+        assert_eq!(response.name, "Shell Grafton Street");
+    }
+
+    #[test]
+    fn test_fuel_station_response_does_not_include_created_at() {
+        // Compile-time guarantee: FuelStationResponse only has id + name
+        let station = make_station(1, "BP");
+        let response = FuelStationResponse::from(station);
+        let _ = response.id;
+        let _ = response.name;
+    }
+
+    // --- VehicleResponse::from_vehicle ---
+
+    #[test]
+    fn test_vehicle_response_maps_all_fields() {
+        let vehicle = make_vehicle(3, "Toyota", "Corolla", "241-D-12345");
+        let response = VehicleResponse::from_vehicle(vehicle, false, Some("owner".to_string()));
+        assert_eq!(response.id, 3);
+        assert_eq!(response.make, "Toyota");
+        assert_eq!(response.model, "Corolla");
+        assert_eq!(response.registration, "241-D-12345");
+        assert!(!response.is_shared);
+        assert_eq!(response.permission_level, Some("owner".to_string()));
+    }
+
+    #[test]
+    fn test_vehicle_response_from_shared_vehicle() {
+        let vehicle = make_vehicle(5, "Ford", "Focus", "222-G-9999");
+        let response = VehicleResponse::from_vehicle(vehicle, true, Some("write".to_string()));
+        assert!(response.is_shared);
+        assert_eq!(response.permission_level, Some("write".to_string()));
+    }
 }

--- a/src/vehicle_share_handlers.rs
+++ b/src/vehicle_share_handlers.rs
@@ -1,0 +1,315 @@
+use axum::{
+    Json, Router,
+    extract::State,
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{delete, get},
+};
+use axum_extra::{
+    TypedHeader,
+    headers::{Authorization, authorization::Bearer},
+};
+use deadpool_diesel::postgres::Pool;
+use diesel::prelude::*;
+
+use crate::AppState;
+use crate::auth::AuthConfig;
+use crate::handlers::internal_error;
+use crate::models::{NewVehicleShare, User, VehicleShare};
+use crate::schema::{users, vehicle_shares, vehicles};
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/api/vehicle-shares",
+            get(list_shared_vehicles).post(create_share),
+        )
+        .route("/api/vehicle-shares/{id}", delete(delete_share))
+}
+
+#[derive(Debug, Clone)]
+pub struct AuthUser {
+    pub user_id: i32,
+    #[allow(dead_code)]
+    pub email: String,
+}
+
+fn extract_auth_user(
+    TypedHeader(Authorization(bearer)): TypedHeader<Authorization<Bearer>>,
+) -> Result<AuthUser, (StatusCode, String)> {
+    let auth_config = AuthConfig::new();
+    let claims = auth_config
+        .validate_token(bearer.token())
+        .map_err(|_| (StatusCode::UNAUTHORIZED, "Invalid token".to_string()))?;
+
+    Ok(AuthUser {
+        user_id: claims.user_id,
+        email: claims.sub,
+    })
+}
+
+#[derive(serde::Serialize)]
+pub struct VehicleShareResponse {
+    pub id: i32,
+    pub vehicle_id: i32,
+    pub vehicle_make: String,
+    pub vehicle_model: String,
+    pub vehicle_registration: String,
+    pub owner_email: String,
+    pub permission_level: String,
+}
+
+pub async fn list_shared_vehicles(
+    State(pool): State<Pool>,
+    auth_header: TypedHeader<Authorization<Bearer>>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let auth_user = extract_auth_user(auth_header)?;
+    let conn = pool.get().await.map_err(internal_error)?;
+    let user_id = auth_user.user_id;
+
+    let shares: Vec<(VehicleShare, String, String, String, String)> = conn
+        .interact(move |conn| {
+            vehicle_shares::table
+                .inner_join(vehicles::table)
+                .inner_join(users::table.on(vehicles::owner_id.eq(users::id)))
+                .filter(vehicle_shares::shared_with_user_id.eq(user_id))
+                .select((
+                    VehicleShare::as_select(),
+                    vehicles::make,
+                    vehicles::model,
+                    vehicles::registration,
+                    users::email,
+                ))
+                .order(vehicle_shares::created_at.desc())
+                .load(conn)
+        })
+        .await
+        .map_err(internal_error)?
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("DB error: {}", e),
+            )
+        })?;
+
+    let response: Vec<VehicleShareResponse> = shares
+        .into_iter()
+        .map(
+            |(share, make, model, registration, owner_email)| VehicleShareResponse {
+                id: share.id,
+                vehicle_id: share.vehicle_id,
+                vehicle_make: make,
+                vehicle_model: model,
+                vehicle_registration: registration,
+                owner_email,
+                permission_level: share.permission_level,
+            },
+        )
+        .collect();
+
+    Ok(Json(response))
+}
+
+#[derive(serde::Deserialize)]
+pub struct CreateShareRequest {
+    pub vehicle_id: i32,
+    pub shared_with_email: String,
+    pub permission_level: String,
+}
+
+pub async fn create_share(
+    State(pool): State<Pool>,
+    auth_header: TypedHeader<Authorization<Bearer>>,
+    Json(payload): Json<CreateShareRequest>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let auth_user = extract_auth_user(auth_header)?;
+    let conn = pool.get().await.map_err(internal_error)?;
+    let owner_id = auth_user.user_id;
+
+    // Validate vehicle ownership
+    let vehicle_exists: bool = conn
+        .interact(move |conn| {
+            vehicles::table
+                .filter(vehicles::id.eq(payload.vehicle_id))
+                .filter(vehicles::owner_id.eq(owner_id))
+                .first::<crate::models::Vehicle>(conn)
+                .optional()
+        })
+        .await
+        .map_err(internal_error)?
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("DB error: {}", e),
+            )
+        })?
+        .map(|_| true)
+        .unwrap_or(false);
+
+    if !vehicle_exists {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "You don't own this vehicle".to_string(),
+        ));
+    }
+
+    // Find recipient user by email
+    let recipient_email = payload.shared_with_email.clone();
+    let recipient: Option<User> = conn
+        .interact(move |conn| {
+            users::table
+                .filter(users::email.eq(&recipient_email))
+                .first(conn)
+                .optional()
+        })
+        .await
+        .map_err(internal_error)?
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("DB error: {}", e),
+            )
+        })?;
+
+    let recipient = match recipient {
+        Some(user) => user,
+        None => {
+            return Err((
+                StatusCode::NOT_FOUND,
+                format!("User with email '{}' not found", payload.shared_with_email),
+            ));
+        }
+    };
+
+    // Don't allow sharing with yourself
+    if recipient.id == owner_id {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Cannot share a vehicle with yourself".to_string(),
+        ));
+    }
+
+    // Validate permission level
+    let permission_level = payload.permission_level.to_lowercase();
+    if !matches!(permission_level.as_str(), "read" | "write") {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Permission level must be 'read' or 'write'".to_string(),
+        ));
+    }
+
+    let vehicle_id = payload.vehicle_id;
+    let shared_with_user_id = recipient.id;
+    let permission_level_clone = permission_level.clone();
+
+    // Check if share already exists
+    let existing_share: Option<VehicleShare> = conn
+        .interact(move |conn| {
+            vehicle_shares::table
+                .filter(vehicle_shares::vehicle_id.eq(vehicle_id))
+                .filter(vehicle_shares::shared_with_user_id.eq(shared_with_user_id))
+                .first(conn)
+                .optional()
+        })
+        .await
+        .map_err(internal_error)?
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("DB error: {}", e),
+            )
+        })?;
+
+    let share = if let Some(existing) = existing_share {
+        // Update existing share
+        conn.interact(move |conn| {
+            diesel::update(vehicle_shares::table.filter(vehicle_shares::id.eq(existing.id)))
+                .set(vehicle_shares::permission_level.eq(permission_level_clone))
+                .returning(VehicleShare::as_returning())
+                .get_result(conn)
+        })
+        .await
+        .map_err(internal_error)?
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("DB error: {}", e),
+            )
+        })?
+    } else {
+        // Insert new share
+        conn.interact(move |conn| {
+            diesel::insert_into(vehicle_shares::table)
+                .values(NewVehicleShare {
+                    vehicle_id,
+                    shared_with_user_id,
+                    permission_level: Some(permission_level),
+                })
+                .returning(VehicleShare::as_returning())
+                .get_result(conn)
+        })
+        .await
+        .map_err(internal_error)?
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("DB error: {}", e),
+            )
+        })?
+    };
+
+    Ok((StatusCode::CREATED, Json(share)))
+}
+
+pub async fn delete_share(
+    State(pool): State<Pool>,
+    auth_header: TypedHeader<Authorization<Bearer>>,
+    axum::extract::Path(share_id): axum::extract::Path<i32>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let auth_user = extract_auth_user(auth_header)?;
+    let conn = pool.get().await.map_err(internal_error)?;
+    let user_id = auth_user.user_id;
+
+    // Check if user owns the vehicle that this share belongs to
+    let can_delete: bool = conn
+        .interact(move |conn| {
+            vehicle_shares::table
+                .inner_join(vehicles::table)
+                .filter(vehicle_shares::id.eq(share_id))
+                .filter(vehicles::owner_id.eq(user_id))
+                .select(vehicle_shares::id)
+                .first::<i32>(conn)
+                .optional()
+        })
+        .await
+        .map_err(internal_error)?
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("DB error: {}", e),
+            )
+        })?
+        .map(|_| true)
+        .unwrap_or(false);
+
+    if !can_delete {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "You don't have permission to delete this share".to_string(),
+        ));
+    }
+
+    conn.interact(move |conn| {
+        diesel::delete(vehicle_shares::table.filter(vehicle_shares::id.eq(share_id))).execute(conn)
+    })
+    .await
+    .map_err(internal_error)?
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("DB error: {}", e),
+        )
+    })?;
+
+    Ok(StatusCode::NO_CONTENT)
+}


### PR DESCRIPTION
- Add vehicle_shares API endpoints (POST, GET, DELETE)
- Implement read/write permission levels for shared vehicles
- Update vehicle list to return owned + shared vehicles
- Add permission checks for fuel entry operations
- Switch from query params to JWT Bearer token auth
- Add frontend sharing UI with permission badges