### PR TITLE
Add custom favicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,6 @@ target/
 .env*
 **/.diesel_lock
 
-# Frontend build output — ignore built assets
-src/pkg/index.html
-src/pkg/assets/
-src/pkg/.vite/
+# Frontend build output — ignore all built assets
+src/pkg/
 **/node_modules/

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Deesl Fuel Tracker</title>
   </head>
   <body>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="20" fill="#2563eb"/>
+  <path d="M30 35 L30 75 L50 75 L50 35 L45 30 L35 30 Z" fill="white"/>
+  <rect x="32" y="38" width="16" height="8" fill="#2563eb"/>
+  <path d="M55 50 L55 30 L75 30 L75 60 C75 65 70 70 65 70 L55 70" fill="none" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="65" cy="75" r="3" fill="white"/>
+</svg>

--- a/frontend/static/index.html
+++ b/frontend/static/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Deesl Fuel Tracker</title>
     <script>
       (function() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::TcpListener;
 use tower_http::cors::{AllowOrigin, CorsLayer};
-use tower_http::services::ServeDir;
+use tower_http::services::{ServeDir, ServeFile};
 use tower_http::trace::TraceLayer;
 use tower_livereload::LiveReloadLayer;
 use tracing::info;
@@ -30,19 +30,6 @@ async fn serve_openapi() -> axum::response::Json<String> {
 async fn serve_version() -> axum::response::Json<serde_json::Value> {
     const VERSION: &str = env!("CARGO_PKG_VERSION");
     axum::response::Json(serde_json::json!({ "version": VERSION }))
-}
-
-async fn serve_index() -> impl IntoResponse {
-    match tokio::fs::read_to_string("src/pkg/index.html").await {
-        Ok(content) => axum::response::Html(content),
-        Err(err) => {
-            tracing::error!("Failed to read index.html: {}", err);
-            axum::response::Html(
-                "<h1>Server Error</h1><p>Failed to load application. Please try again later.</p>"
-                    .to_string(),
-            )
-        }
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -118,8 +105,7 @@ async fn main() {
         .merge(vehicle_fuel_handlers::router())
         .merge(vehicle_share_handlers::router())
         .merge(import_handlers::router())
-        .nest_service("/assets", ServeDir::new("src/pkg/assets"))
-        .fallback(serve_index)
+        .fallback_service(ServeDir::new("src/pkg").fallback(ServeFile::new("src/pkg/index.html")))
         .layer(middleware::from_fn(add_cache_control_headers))
         .layer(TraceLayer::new_for_http())
         .with_state(app_state);


### PR DESCRIPTION
Closes #20

Replace the generic browser favicon with a custom SVG fuel pump icon.

Simplifies asset serving by using `fallback_service` with ServeDir instead of separate routes for favicon and assets.