### PR TITLE
Simplify docker-compose by removing app service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: 0
+      RUST_BACKTRACE: 1
+      CARGO_PROFILE_DEV_DEBUG: 0
     steps:
       - uses: actions/checkout@v4
 
@@ -17,14 +21,12 @@ jobs:
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "ci"
 
       - name: Check formatting
         run: cargo fmt -- --check
 
       - name: Clippy
-        run: cargo clippy --all --tests --all-features --no-deps -- -D warnings
+        run: cargo clippy --locked --all --tests --all-features --no-deps -- -D warnings
 
   test:
     name: Test
@@ -33,6 +35,9 @@ jobs:
       GOOGLE_CLIENT_ID: placeholder
       GOOGLE_CLIENT_SECRET: placeholder
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/deesl_test
+      CARGO_INCREMENTAL: 0
+      RUST_BACKTRACE: 1
+      CARGO_PROFILE_TEST_DEBUG: 0
 
     services:
       postgres:
@@ -57,8 +62,6 @@ jobs:
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "ci"
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libpq-dev
@@ -78,4 +81,4 @@ jobs:
         run: diesel migration run
 
       - name: Run tests
-        run: cargo test --all-features
+        run: cargo test --locked --all-features

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,20 +16,5 @@ services:
       timeout: 15s
       retries: 5
 
-  app:
-    build: .
-    container_name: app
-    environment:
-      DATABASE_URL: postgres://postgres:postgres@db:5432/deesl
-      HOST: 0.0.0.0
-      PORT: 8000
-      ENVIRONMENT: production
-      CORS_ORIGINS: ""
-    ports:
-      - "8000:8000"
-    depends_on:
-      db:
-        condition: service_healthy
-
 volumes:
   pgdata:


### PR DESCRIPTION
Remove the app service from docker-compose.yml, keeping only the database service.

This simplifies the development workflow:
- Run database: docker compose up db
- Run app: cargo run (connects to localhost:5432)
- No more maintaining separate DATABASE_URL configs for docker vs cargo
- Single consistent database connection string everywhere

## CI Optimizations

Also fixes slow CI builds and cache misses:

- **Separate caches** - Removed `shared-key: "ci"` so lint and test jobs don't interfere with each other
- **`--locked` flag** - Uses exact versions from `Cargo.lock` for reproducible builds
- **`CARGO_INCREMENTAL: 0`** - More cache-friendly builds (smaller, more stable artifacts)
- **`RUST_BACKTRACE: 1`** - Better debugging for test failures
- **`CARGO_PROFILE_DEV_DEBUG: 0`** and `CARGO_PROFILE_TEST_DEBUG: 0` - Disables debug symbols for smaller cache and faster builds