### PR TITLE
Add ability to edit existing fuel entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "deesl"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "askama",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deesl"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 
 [lib]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::auth::{AuthUser, AuthUserRedirect};
-use crate::models::{FuelStation, NewFuelStation, NewVehicle, User, Vehicle};
+use crate::models::{FuelEntry, FuelStation, NewFuelStation, NewVehicle, User, Vehicle};
 use crate::schema::{fuel_stations, users, vehicles};
 
 /// Utility function for mapping any error into a `500 Internal Server Error`
@@ -817,6 +817,110 @@ pub async fn htmx_recent_entries(
 
     let template = RecentEntriesTemplate { entries };
     Ok(Html(template.render().map_err(internal_error)?))
+}
+
+#[derive(Template)]
+#[template(path = "edit_fuel_entry.html")]
+pub struct EditFuelEntryTemplate {
+    pub logged_in: bool,
+    pub entry: FuelEntry,
+    pub vehicle: Vehicle,
+    pub filled_at_formatted: String,
+}
+
+pub async fn edit_fuel_entry(
+    State(pool): State<Pool>,
+    AuthUserRedirect(user): AuthUserRedirect,
+    axum::extract::Path(entry_id): axum::extract::Path<i32>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let conn = pool.get().await.map_err(internal_error)?;
+    let user_id = user.user_id;
+
+    let result: Option<(FuelEntry, Vehicle)> = conn
+        .interact(move |conn| {
+            crate::schema::fuel_entries::table
+                .inner_join(vehicles::table)
+                .filter(crate::schema::fuel_entries::id.eq(entry_id))
+                .filter(vehicles::owner_id.eq(user_id))
+                .select((FuelEntry::as_select(), Vehicle::as_select()))
+                .first::<(FuelEntry, Vehicle)>(conn)
+                .optional()
+        })
+        .await
+        .map_err(internal_error)?
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let (entry, vehicle) = result.ok_or((StatusCode::NOT_FOUND, "Entry not found".to_string()))?;
+
+    let filled_at_formatted = entry.filled_at.format("%Y-%m-%dT%H:%M").to_string();
+
+    let template = EditFuelEntryTemplate {
+        logged_in: true,
+        entry,
+        vehicle,
+        filled_at_formatted,
+    };
+    Ok(Html(template.render().map_err(internal_error)?))
+}
+
+#[derive(Deserialize)]
+pub struct UpdateFuelEntryForm {
+    pub mileage_km: i32,
+    pub litres: f64,
+    pub cost: f64,
+    pub filled_at: String,
+}
+
+pub async fn update_fuel_entry(
+    State(pool): State<Pool>,
+    user: AuthUser,
+    axum::extract::Path(entry_id): axum::extract::Path<i32>,
+    Form(payload): Form<UpdateFuelEntryForm>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let conn = pool.get().await.map_err(internal_error)?;
+    let user_id = user.user_id;
+
+    let is_owner: bool = conn
+        .interact(move |conn| {
+            crate::schema::fuel_entries::table
+                .inner_join(vehicles::table)
+                .filter(crate::schema::fuel_entries::id.eq(entry_id))
+                .filter(vehicles::owner_id.eq(user_id))
+                .select(crate::schema::fuel_entries::id)
+                .first::<i32>(conn)
+                .optional()
+        })
+        .await
+        .map_err(internal_error)?
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .is_some();
+
+    if !is_owner {
+        return Err((StatusCode::FORBIDDEN, "Access denied".to_string()));
+    }
+
+    let filled_at = chrono::NaiveDateTime::parse_from_str(&payload.filled_at, "%Y-%m-%dT%H:%M")
+        .map_err(|_| (StatusCode::BAD_REQUEST, "Invalid date format".to_string()))?;
+
+    conn.interact(move |conn| {
+        diesel::update(
+            crate::schema::fuel_entries::table.filter(crate::schema::fuel_entries::id.eq(entry_id)),
+        )
+        .set(crate::models::UpdateFuelEntry {
+            mileage_km: Some(payload.mileage_km),
+            litres: Some(payload.litres),
+            cost: Some(payload.cost),
+            filled_at: Some(filled_at),
+        })
+        .execute(conn)
+    })
+    .await
+    .map_err(internal_error)?
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let mut headers = HeaderMap::new();
+    headers.insert("HX-Redirect", "/dashboard".parse().unwrap());
+    Ok((headers, Redirect::to("/dashboard")))
 }
 
 #[derive(Template)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,8 @@ async fn main() {
         .route("/vehicles/new", get(handlers::new_vehicle))
         .route("/fuel-entries/new", get(handlers::new_fuel_entry))
         .route("/fuel-entries", post(handlers::create_fuel_entry))
+        .route("/fuel-entries/{id}/edit", get(handlers::edit_fuel_entry))
+        .route("/fuel-entries/{id}", post(handlers::update_fuel_entry))
         .route("/import", get(handlers::import_page))
         .route("/htmx/import/preview", post(handlers::htmx_import_preview))
         .route("/htmx/import/execute", post(handlers::htmx_import_execute))

--- a/src/models.rs
+++ b/src/models.rs
@@ -89,6 +89,16 @@ pub struct NewFuelEntry {
     pub filled_at: Option<NaiveDateTime>,
 }
 
+#[derive(AsChangeset, serde::Deserialize)]
+#[diesel(table_name = crate::schema::fuel_entries)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct UpdateFuelEntry {
+    pub mileage_km: Option<i32>,
+    pub litres: Option<f64>,
+    pub cost: Option<f64>,
+    pub filled_at: Option<NaiveDateTime>,
+}
+
 #[derive(Queryable, Selectable, serde::Serialize)]
 #[diesel(table_name = crate::schema::vehicle_shares)]
 #[diesel(check_for_backend(diesel::pg::Pg))]

--- a/templates/add_fuel_entry.html
+++ b/templates/add_fuel_entry.html
@@ -6,7 +6,7 @@
 <div class="card" style="max-width: 500px; margin: 0 auto;">
     <h1>Add Fuel Entry</h1>
     
-    <form hx-post="/fuel-entries" hx-target="#entry-result" class="add-entry-form">
+    <form action="/fuel-entries" method="post" class="add-entry-form">
         <label>
             Vehicle
             <select name="vehicle_id" required>
@@ -40,8 +40,6 @@
             <button type="submit">Save Entry</button>
             <a href="/dashboard" class="btn btn-outline">Cancel</a>
         </div>
-        
-        <div id="entry-result"></div>
     </form>
 </div>
 {% endblock %}

--- a/templates/edit_fuel_entry.html
+++ b/templates/edit_fuel_entry.html
@@ -1,0 +1,44 @@
+{% extends "layout.html" %}
+
+{% block title %}Edit Fuel Entry - Deesl{% endblock %}
+
+{% block content %}
+<div class="card" style="max-width: 500px; margin: 0 auto;">
+    <h1>Edit Fuel Entry</h1>
+    
+    <form hx-post="/fuel-entries/{{ entry.id }}" hx-target="#entry-result" class="add-entry-form">
+        <label>
+            Vehicle
+            <input type="text" value="{{ vehicle.make }} {{ vehicle.model }} ({{ vehicle.registration }})" disabled>
+            <input type="hidden" name="vehicle_id" value="{{ entry.vehicle_id }}">
+        </label>
+
+        <label>
+            Mileage (km)
+            <input type="number" name="mileage_km" value="{{ entry.mileage_km }}" required>
+        </label>
+        
+        <label>
+            Litres
+            <input type="number" step="0.01" name="litres" value="{{ entry.litres }}" required>
+        </label>
+        
+        <label>
+            Cost
+            <input type="number" step="0.01" name="cost" value="{{ entry.cost }}" required>
+        </label>
+
+        <label>
+            Date/Time
+            <input type="datetime-local" name="filled_at" value="{{ filled_at_formatted }}" required>
+        </label>
+        
+        <div style="display: flex; gap: 1rem; margin-top: 1rem;">
+            <button type="submit">Update Entry</button>
+            <a href="/dashboard" class="btn btn-outline">Cancel</a>
+        </div>
+        
+        <div id="entry-result"></div>
+    </form>
+</div>
+{% endblock %}

--- a/templates/edit_fuel_entry.html
+++ b/templates/edit_fuel_entry.html
@@ -6,7 +6,7 @@
 <div class="card" style="max-width: 500px; margin: 0 auto;">
     <h1>Edit Fuel Entry</h1>
     
-    <form hx-post="/fuel-entries/{{ entry.id }}" hx-target="#entry-result" class="add-entry-form">
+    <form action="/fuel-entries/{{ entry.id }}" method="post" class="add-entry-form">
         <label>
             Vehicle
             <input type="text" value="{{ vehicle.make }} {{ vehicle.model }} ({{ vehicle.registration }})" disabled>
@@ -37,8 +37,6 @@
             <button type="submit">Update Entry</button>
             <a href="/dashboard" class="btn btn-outline">Cancel</a>
         </div>
-        
-        <div id="entry-result"></div>
     </form>
 </div>
 {% endblock %}

--- a/templates/fragments/recent_entries.html
+++ b/templates/fragments/recent_entries.html
@@ -8,6 +8,7 @@
                 <th style="padding: 0.5rem;">Vehicle</th>
                 <th style="padding: 0.5rem;">Litres</th>
                 <th style="padding: 0.5rem;">Cost</th>
+                <th style="padding: 0.5rem;"></th>
             </tr>
         </thead>
         <tbody>
@@ -17,6 +18,9 @@
                 <td style="padding: 0.5rem;">{{ v.registration }}</td>
                 <td style="padding: 0.5rem;">{{ self.format_float(e.litres) }} L</td>
                 <td style="padding: 0.5rem;">€{{ self.format_float(e.cost) }}</td>
+                <td style="padding: 0.5rem; text-align: right;">
+                    <a href="/fuel-entries/{{ e.id }}/edit" class="btn btn-small btn-outline">Edit</a>
+                </td>
             </tr>
             {% endfor %}
         </tbody>

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -52,6 +52,8 @@ pub async fn create_test_app(pool: Pool) -> Router {
         .route("/vehicles/new", get(handlers::new_vehicle))
         .route("/fuel-entries/new", get(handlers::new_fuel_entry))
         .route("/fuel-entries", post(handlers::create_fuel_entry))
+        .route("/fuel-entries/{id}/edit", get(handlers::edit_fuel_entry))
+        .route("/fuel-entries/{id}", post(handlers::update_fuel_entry))
         .route("/import", get(handlers::import_page))
         .route("/htmx/import/preview", post(handlers::htmx_import_preview))
         .route("/htmx/import/execute", post(handlers::htmx_import_execute))


### PR DESCRIPTION
Closes #26

Adds GET /fuel-entries/{id}/edit route and POST /fuel-entries/{id} handler for updating existing fuel entries. Also fixes HTMX form submission on add/edit forms to use regular form posts for proper redirects to dashboard.