### PR TITLE
Add Station Manager

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -631,6 +631,7 @@ pub async fn create_vehicle(
 pub struct AddFuelEntryTemplate {
     pub logged_in: bool,
     pub vehicles: Vec<Vehicle>,
+    pub stations: Vec<FuelStation>,
     pub current_time: String,
 }
 
@@ -641,12 +642,21 @@ pub async fn new_fuel_entry(
     let conn = pool.get().await.map_err(internal_error)?;
     let user_id = user.user_id;
 
-    let user_vehicles: Vec<Vehicle> = conn
+    let (user_vehicles, user_stations): (Vec<Vehicle>, Vec<FuelStation>) = conn
         .interact(move |conn| {
-            vehicles::table
+            let vehicles = vehicles::table
                 .filter(vehicles::owner_id.eq(user_id))
                 .order(vehicles::registration)
-                .load::<Vehicle>(conn)
+                .load::<Vehicle>(conn)?;
+            let stations = fuel_stations::table
+                .filter(
+                    fuel_stations::user_id
+                        .eq(user_id)
+                        .or(fuel_stations::user_id.is_null()),
+                )
+                .order(fuel_stations::name)
+                .load::<FuelStation>(conn)?;
+            Ok::<(Vec<Vehicle>, Vec<FuelStation>), diesel::result::Error>((vehicles, stations))
         })
         .await
         .map_err(internal_error)?
@@ -655,6 +665,7 @@ pub async fn new_fuel_entry(
     let template = AddFuelEntryTemplate {
         logged_in: true,
         vehicles: user_vehicles,
+        stations: user_stations,
         current_time: chrono::Local::now().format("%Y-%m-%dT%H:%M").to_string(),
     };
     Ok(Html(template.render().map_err(internal_error)?))
@@ -663,6 +674,7 @@ pub async fn new_fuel_entry(
 #[derive(Deserialize)]
 pub struct CreateFuelEntryForm {
     pub vehicle_id: i32,
+    pub station_id: i32,
     pub mileage_km: i32,
     pub litres: f64,
     pub cost: f64,
@@ -703,7 +715,7 @@ pub async fn create_fuel_entry(
         diesel::insert_into(crate::schema::fuel_entries::table)
             .values(crate::models::NewFuelEntry {
                 vehicle_id,
-                station_id: None,
+                station_id: Some(payload.station_id),
                 mileage_km: payload.mileage_km,
                 litres: payload.litres,
                 cost: payload.cost,
@@ -825,6 +837,7 @@ pub struct EditFuelEntryTemplate {
     pub logged_in: bool,
     pub entry: FuelEntry,
     pub vehicle: Vehicle,
+    pub stations: Vec<FuelStation>,
     pub filled_at_formatted: String,
 }
 
@@ -836,15 +849,27 @@ pub async fn edit_fuel_entry(
     let conn = pool.get().await.map_err(internal_error)?;
     let user_id = user.user_id;
 
-    let result: Option<(FuelEntry, Vehicle)> = conn
+    let (result, stations): (Option<(FuelEntry, Vehicle)>, Vec<FuelStation>) = conn
         .interact(move |conn| {
-            crate::schema::fuel_entries::table
+            let entry_result = crate::schema::fuel_entries::table
                 .inner_join(vehicles::table)
                 .filter(crate::schema::fuel_entries::id.eq(entry_id))
                 .filter(vehicles::owner_id.eq(user_id))
                 .select((FuelEntry::as_select(), Vehicle::as_select()))
                 .first::<(FuelEntry, Vehicle)>(conn)
-                .optional()
+                .optional()?;
+            let stations = fuel_stations::table
+                .filter(
+                    fuel_stations::user_id
+                        .eq(user_id)
+                        .or(fuel_stations::user_id.is_null()),
+                )
+                .order(fuel_stations::name)
+                .load::<FuelStation>(conn)?;
+            Ok::<(Option<(FuelEntry, Vehicle)>, Vec<FuelStation>), diesel::result::Error>((
+                entry_result,
+                stations,
+            ))
         })
         .await
         .map_err(internal_error)?
@@ -858,6 +883,7 @@ pub async fn edit_fuel_entry(
         logged_in: true,
         entry,
         vehicle,
+        stations,
         filled_at_formatted,
     };
     Ok(Html(template.render().map_err(internal_error)?))
@@ -865,6 +891,7 @@ pub async fn edit_fuel_entry(
 
 #[derive(Deserialize)]
 pub struct UpdateFuelEntryForm {
+    pub station_id: i32,
     pub mileage_km: i32,
     pub litres: f64,
     pub cost: f64,
@@ -907,6 +934,7 @@ pub async fn update_fuel_entry(
             crate::schema::fuel_entries::table.filter(crate::schema::fuel_entries::id.eq(entry_id)),
         )
         .set(crate::models::UpdateFuelEntry {
+            station_id: Some(payload.station_id),
             mileage_km: Some(payload.mileage_km),
             litres: Some(payload.litres),
             cost: Some(payload.cost),

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1134,6 +1134,156 @@ pub async fn htmx_import_execute(
     Ok(Html(template.render().map_err(internal_error)?))
 }
 
+#[derive(Template)]
+#[template(path = "stations.html")]
+pub struct StationsTemplate {
+    pub logged_in: bool,
+    pub stations: Vec<FuelStation>,
+}
+
+pub async fn stations_page(
+    State(pool): State<Pool>,
+    AuthUserRedirect(user): AuthUserRedirect,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let conn = pool.get().await.map_err(internal_error)?;
+    let user_id = user.user_id;
+
+    let stations: Vec<FuelStation> = conn
+        .interact(move |conn| {
+            fuel_stations::table
+                .filter(
+                    fuel_stations::user_id
+                        .eq(user_id)
+                        .or(fuel_stations::user_id.is_null()),
+                )
+                .order(fuel_stations::name)
+                .load::<FuelStation>(conn)
+        })
+        .await
+        .map_err(internal_error)?
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let template = StationsTemplate {
+        logged_in: true,
+        stations,
+    };
+    Ok(Html(template.render().map_err(internal_error)?))
+}
+
+#[derive(Deserialize)]
+pub struct CreateStationForm {
+    pub name: String,
+}
+
+pub async fn create_station(
+    State(pool): State<Pool>,
+    user: AuthUser,
+    Form(payload): Form<CreateStationForm>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let conn = pool.get().await.map_err(internal_error)?;
+    let user_id = user.user_id;
+
+    conn.interact(move |conn| {
+        diesel::insert_into(fuel_stations::table)
+            .values(NewFuelStation {
+                name: payload.name,
+                user_id: Some(user_id),
+            })
+            .execute(conn)
+    })
+    .await
+    .map_err(internal_error)?
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let mut headers = HeaderMap::new();
+    headers.insert("HX-Redirect", "/stations".parse().unwrap());
+    Ok((headers, Redirect::to("/stations")))
+}
+
+#[derive(Deserialize)]
+pub struct UpdateStationForm {
+    pub name: String,
+}
+
+pub async fn update_station(
+    State(pool): State<Pool>,
+    user: AuthUser,
+    axum::extract::Path(station_id): axum::extract::Path<i32>,
+    Form(payload): Form<UpdateStationForm>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let conn = pool.get().await.map_err(internal_error)?;
+    let user_id = user.user_id;
+
+    let is_owner: bool = conn
+        .interact(move |conn| {
+            fuel_stations::table
+                .filter(fuel_stations::id.eq(station_id))
+                .filter(fuel_stations::user_id.eq(user_id))
+                .select(fuel_stations::id)
+                .first::<i32>(conn)
+                .optional()
+        })
+        .await
+        .map_err(internal_error)?
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .is_some();
+
+    if !is_owner {
+        return Err((StatusCode::FORBIDDEN, "Access denied".to_string()));
+    }
+
+    conn.interact(move |conn| {
+        diesel::update(fuel_stations::table.filter(fuel_stations::id.eq(station_id)))
+            .set(crate::models::UpdateFuelStation {
+                name: Some(payload.name),
+            })
+            .execute(conn)
+    })
+    .await
+    .map_err(internal_error)?
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let mut headers = HeaderMap::new();
+    headers.insert("HX-Redirect", "/stations".parse().unwrap());
+    Ok((headers, Redirect::to("/stations")))
+}
+
+pub async fn delete_station(
+    State(pool): State<Pool>,
+    user: AuthUser,
+    axum::extract::Path(station_id): axum::extract::Path<i32>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let conn = pool.get().await.map_err(internal_error)?;
+    let user_id = user.user_id;
+
+    let is_owner: bool = conn
+        .interact(move |conn| {
+            fuel_stations::table
+                .filter(fuel_stations::id.eq(station_id))
+                .filter(fuel_stations::user_id.eq(user_id))
+                .select(fuel_stations::id)
+                .first::<i32>(conn)
+                .optional()
+        })
+        .await
+        .map_err(internal_error)?
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .is_some();
+
+    if !is_owner {
+        return Err((StatusCode::FORBIDDEN, "Access denied".to_string()));
+    }
+
+    conn.interact(move |conn| {
+        diesel::delete(fuel_stations::table.filter(fuel_stations::id.eq(station_id))).execute(conn)
+    })
+    .await
+    .map_err(internal_error)?
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(Html(""))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,12 @@ async fn main() {
         .route("/fuel-entries", post(handlers::create_fuel_entry))
         .route("/fuel-entries/{id}/edit", get(handlers::edit_fuel_entry))
         .route("/fuel-entries/{id}", post(handlers::update_fuel_entry))
+        .route(
+            "/stations",
+            get(handlers::stations_page).post(handlers::create_station),
+        )
+        .route("/stations/{id}", post(handlers::update_station))
+        .route("/stations/{id}", delete(handlers::delete_station))
         .route("/import", get(handlers::import_page))
         .route("/htmx/import/preview", post(handlers::htmx_import_preview))
         .route("/htmx/import/execute", post(handlers::htmx_import_execute))

--- a/src/models.rs
+++ b/src/models.rs
@@ -100,6 +100,7 @@ pub struct NewFuelEntry {
 #[diesel(table_name = crate::schema::fuel_entries)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct UpdateFuelEntry {
+    pub station_id: Option<i32>,
     pub mileage_km: Option<i32>,
     pub litres: Option<f64>,
     pub cost: Option<f64>,

--- a/src/models.rs
+++ b/src/models.rs
@@ -63,6 +63,13 @@ pub struct NewFuelStation {
     pub user_id: Option<i32>,
 }
 
+#[derive(AsChangeset, serde::Deserialize)]
+#[diesel(table_name = crate::schema::fuel_stations)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct UpdateFuelStation {
+    pub name: Option<String>,
+}
+
 #[derive(Queryable, Selectable, serde::Serialize)]
 #[diesel(table_name = crate::schema::fuel_entries)]
 #[diesel(check_for_backend(diesel::pg::Pg))]

--- a/templates/add_fuel_entry.html
+++ b/templates/add_fuel_entry.html
@@ -17,6 +17,15 @@
         </label>
 
         <label>
+            Station
+            <select name="station_id" required>
+                {% for station in stations %}
+                <option value="{{ station.id }}">{{ station.name }}</option>
+                {% endfor %}
+            </select>
+        </label>
+
+        <label>
             Mileage (km)
             <input type="number" name="mileage_km" placeholder="Current odometer" required>
         </label>

--- a/templates/edit_fuel_entry.html
+++ b/templates/edit_fuel_entry.html
@@ -10,7 +10,15 @@
         <label>
             Vehicle
             <input type="text" value="{{ vehicle.make }} {{ vehicle.model }} ({{ vehicle.registration }})" disabled>
-            <input type="hidden" name="vehicle_id" value="{{ entry.vehicle_id }}">
+        </label>
+
+        <label>
+            Station
+            <select name="station_id" required>
+                {% for station in stations %}
+                <option value="{{ station.id }}" {% if entry.station_id.is_some() && entry.station_id.unwrap() == station.id %}selected{% endif %}>{{ station.name }}</option>
+                {% endfor %}
+            </select>
         </label>
 
         <label>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -138,6 +138,7 @@
                 {% if logged_in %}
                     <a href="/dashboard">Dashboard</a>
                     <a href="/vehicles">Vehicles</a>
+                    <a href="/stations">Stations</a>
                     <a href="/settings">Settings</a>
                     <a href="/logout">Logout</a>
                 {% else %}

--- a/templates/stations.html
+++ b/templates/stations.html
@@ -1,0 +1,92 @@
+{% extends "layout.html" %}
+
+{% block title %}Station Manager - Deesl{% endblock %}
+
+{% block content %}
+<div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 2rem;">
+    <h1>Station Manager</h1>
+    <a href="/dashboard" class="btn btn-outline">Back to Dashboard</a>
+</div>
+
+<div class="card" style="margin-bottom: 2rem;">
+    <h3>Add New Station</h3>
+    <form action="/stations" method="post" style="display: flex; gap: 1rem; align-items: flex-end;">
+        <label style="flex: 1; margin-bottom: 0;">
+            Station Name
+            <input type="text" name="name" placeholder="e.g., Shell, Circle K" required>
+        </label>
+        <button type="submit">Add Station</button>
+    </form>
+</div>
+
+<div class="card">
+    <h3>Your Stations</h3>
+    {% if stations.is_empty() %}
+        <p style="color: var(--text-muted);">No stations yet. Add your first station above.</p>
+    {% else %}
+        <table style="width: 100%; border-collapse: collapse;">
+            <thead>
+                <tr style="text-align: left; border-bottom: 1px solid var(--border);">
+                    <th style="padding: 0.75rem;">Name</th>
+                    <th style="padding: 0.75rem; width: 200px;">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for station in stations %}
+                <tr style="border-bottom: 1px solid var(--border);" id="station-{{ station.id }}">
+                    <td style="padding: 0.75rem;">
+                        {% if station.user_id.is_none() %}
+                            <span style="color: var(--text-muted); font-style: italic;">{{ station.name }} (global)</span>
+                        {% else %}
+                            <span id="station-name-{{ station.id }}">{{ station.name }}</span>
+                        {% endif %}
+                    </td>
+                    <td style="padding: 0.75rem;">
+                        {% if station.user_id.is_some() %}
+                            <div style="display: flex; gap: 0.5rem;">
+                                <button type="button" 
+                                        class="btn btn-small btn-outline"
+                                        onclick="toggleEditForm({{ station.id }})">Edit</button>
+                                <button type="button" 
+                                        class="btn btn-small btn-outline"
+                                        style="color: var(--error); border-color: var(--error);"
+                                        hx-delete="/stations/{{ station.id }}"
+                                        hx-target="#station-{{ station.id }}"
+                                        hx-swap="outerHTML"
+                                        hx-confirm="Are you sure you want to delete this station?">Delete</button>
+                            </div>
+                            <form id="edit-form-{{ station.id }}" 
+                                  action="/stations/{{ station.id }}" 
+                                  method="post" 
+                                  style="display: none; margin-top: 0.5rem;">
+                                <div style="display: flex; gap: 0.5rem;">
+                                    <input type="text" name="name" value="{{ station.name }}" required style="flex: 1;">
+                                    <button type="submit" class="btn btn-small">Save</button>
+                                    <button type="button" class="btn btn-small btn-outline" onclick="toggleEditForm({{ station.id }})">Cancel</button>
+                                </div>
+                            </form>
+                        {% else %}
+                            <span style="color: var(--text-muted); font-size: 0.85rem;">System station</span>
+                        {% endif %}
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+</div>
+
+<script>
+function toggleEditForm(stationId) {
+    const form = document.getElementById('edit-form-' + stationId);
+    const nameSpan = document.getElementById('station-name-' + stationId);
+    if (form.style.display === 'none') {
+        form.style.display = 'block';
+        if (nameSpan) nameSpan.style.display = 'none';
+    } else {
+        form.style.display = 'none';
+        if (nameSpan) nameSpan.style.display = 'inline';
+    }
+}
+</script>
+{% endblock %}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3,8 +3,8 @@ use deadpool_diesel::postgres::{Manager, Pool};
 use diesel::prelude::*;
 
 use deesl::auth::AuthConfig;
-use deesl::models::{NewUser, NewVehicle};
-use deesl::schema::{users, vehicles};
+use deesl::models::{NewFuelStation, NewUser, NewVehicle};
+use deesl::schema::{fuel_stations, users, vehicles};
 
 /// Test user data for creating test fixtures
 #[derive(Clone)]
@@ -170,6 +170,27 @@ pub async fn create_test_vehicle_db(
         .unwrap();
 
     vehicle.id
+}
+
+/// Creates a test fuel station in the database
+pub async fn create_test_station_db(pool: &Pool, user_id: i32, name: &str) -> i32 {
+    let conn = pool.get().await.unwrap();
+    let name = name.to_string();
+
+    let station: deesl::models::FuelStation = conn
+        .interact(move |conn| {
+            diesel::insert_into(fuel_stations::table)
+                .values(NewFuelStation {
+                    name,
+                    user_id: Some(user_id),
+                })
+                .get_result(conn)
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    station.id
 }
 
 pub async fn post_import_csv(

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -54,6 +54,12 @@ pub async fn create_test_app(pool: Pool) -> Router {
         .route("/fuel-entries", post(handlers::create_fuel_entry))
         .route("/fuel-entries/{id}/edit", get(handlers::edit_fuel_entry))
         .route("/fuel-entries/{id}", post(handlers::update_fuel_entry))
+        .route(
+            "/stations",
+            get(handlers::stations_page).post(handlers::create_station),
+        )
+        .route("/stations/{id}", post(handlers::update_station))
+        .route("/stations/{id}", delete(handlers::delete_station))
         .route("/import", get(handlers::import_page))
         .route("/htmx/import/preview", post(handlers::htmx_import_preview))
         .route("/htmx/import/execute", post(handlers::htmx_import_execute))

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -169,9 +169,11 @@ async fn test_create_fuel_entry_and_redirects() {
     let user = common::create_test_user(&env, "fuel_test").await;
     let vehicle_id =
         common::create_test_vehicle_db(&env.pool, user.id, "Ford", "Focus", "FORD-F").await;
+    let station_id = common::create_test_station_db(&env.pool, user.id, "Test Station").await;
 
     let form = [
         ("vehicle_id", vehicle_id.to_string()),
+        ("station_id", station_id.to_string()),
         ("mileage_km", "100500".to_string()),
         ("litres", "50.0".to_string()),
         ("cost", "80.0".to_string()),


### PR DESCRIPTION
Closes #27

Adds a station manager page at /stations for managing fuel stations:
- Create new stations
- Edit existing station names
- Delete stations with confirmation
- View system/global stations (read-only)

Includes Manage Stations button on the dashboard for easy access.