### PR TITLE
More robust file upload handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,7 @@ dependencies = [
  "downcast-rs",
  "itoa",
  "pq-sys",
+ "uuid",
 ]
 
 [[package]]
@@ -3030,6 +3031,7 @@ checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
  "getrandom 0.4.1",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "deesl"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "askama",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ axum-extra = { version = "0.10", features = ["typed-header"] }
 chrono = { version = "0.4.44", features = ["serde"] }
 csv = "1.4"
 deadpool-diesel = { version = "0.6.1", features = ["postgres"] }
-diesel = { version = "2.3.6", features = ["postgres", "chrono"] }
+diesel = { version = "2.3.6", features = ["postgres", "chrono", "uuid"] }
 diesel_migrations = { version = "2.2.0", features = ["postgres"] }
 dotenvy = "0.15.7"
 headers = "0.4"
@@ -40,8 +40,8 @@ oauth2 = "4"
 reqwest = { version = "0.13.2", features = ["json"] }
 urlencoding = "2.1.3"
 tower = "0.5"
+uuid = { version = "1", features = ["v4", "serde"] }
 
 [dev-dependencies]
 axum-test = "18"
-uuid = { version = "1", features = ["v4"] }
 pretty_assertions = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deesl"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 
 [lib]

--- a/migrations/2026-03-04-201656-0000_create_temp_imports/down.sql
+++ b/migrations/2026-03-04-201656-0000_create_temp_imports/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS temp_imports;

--- a/migrations/2026-03-04-201656-0000_create_temp_imports/up.sql
+++ b/migrations/2026-03-04-201656-0000_create_temp_imports/up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE temp_imports (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    vehicle_id INTEGER NOT NULL REFERENCES vehicles(id) ON DELETE CASCADE,
+    csv_data BYTEA NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Create index for cleanup of old imports
+CREATE INDEX idx_temp_imports_created_at ON temp_imports(created_at);
+CREATE INDEX idx_temp_imports_user_id ON temp_imports(user_id);

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -986,6 +986,7 @@ pub async fn import_page(
 #[derive(Template)]
 #[template(path = "fragments/import_mapping.html")]
 pub struct ImportMappingTemplate {
+    pub import_id: String,
     pub vehicle_id: i32,
     pub columns: Vec<String>,
     pub sample_data: Vec<String>,
@@ -1031,6 +1032,41 @@ pub async fn htmx_import_preview(
 
     check_vehicle_write_access(&pool, user.user_id, vehicle_id).await?;
 
+    // Clean up any old imports for this user first
+    let user_id = user.user_id;
+    let conn = pool.get().await.map_err(internal_error)?;
+    let _ = conn
+        .interact(move |conn| {
+            diesel::delete(
+                crate::schema::temp_imports::table
+                    .filter(crate::schema::temp_imports::user_id.eq(user_id))
+                    .filter(
+                        crate::schema::temp_imports::created_at
+                            .lt(chrono::Utc::now().naive_utc() - chrono::Duration::hours(1)),
+                    ),
+            )
+            .execute(conn)
+        })
+        .await
+        .map_err(internal_error)?;
+
+    // Store CSV in temp_imports table
+    let conn = pool.get().await.map_err(internal_error)?;
+    let csv_data_clone = csv_data.clone();
+    let temp_import: crate::models::TempImport = conn
+        .interact(move |conn| {
+            diesel::insert_into(crate::schema::temp_imports::table)
+                .values(crate::models::NewTempImport {
+                    user_id,
+                    vehicle_id,
+                    csv_data: csv_data_clone,
+                })
+                .get_result(conn)
+        })
+        .await
+        .map_err(internal_error)?
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
     let mut reader = csv::Reader::from_reader(&csv_data[..]);
     let headers: Vec<String> = reader
         .headers()
@@ -1071,6 +1107,7 @@ pub async fn htmx_import_preview(
     }
 
     let template = ImportMappingTemplate {
+        import_id: temp_import.id.to_string(),
         vehicle_id,
         columns: headers,
         sample_data: record,
@@ -1093,51 +1130,72 @@ pub struct ImportResultTemplate {
 pub async fn htmx_import_execute(
     State(pool): State<Pool>,
     user: AuthUser,
-    mut multipart: Multipart,
+    Form(payload): Form<std::collections::HashMap<String, String>>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    let mut csv_data: Option<Vec<u8>> = None;
-    let mut vehicle_id: Option<i32> = None;
-    let mut mappings_raw: HashMap<String, String> = HashMap::new();
+    let user_id = user.user_id;
 
-    while let Some(field) = multipart.next_field().await.map_err(internal_error)? {
-        let name = field.name().unwrap_or("").to_string();
-        let data = field.bytes().await.map_err(internal_error)?;
+    // Extract import_id and vehicle_id from form
+    let import_id = payload
+        .get("import_id")
+        .ok_or((StatusCode::BAD_REQUEST, "import_id required".to_string()))?;
+    let vehicle_id = payload
+        .get("vehicle_id")
+        .ok_or((StatusCode::BAD_REQUEST, "vehicle_id required".to_string()))?
+        .parse::<i32>()
+        .map_err(|_| (StatusCode::BAD_REQUEST, "Invalid vehicle_id".to_string()))?;
 
-        match name.as_str() {
-            "file" => csv_data = Some(data.to_vec()),
-            "vehicle_id" => {
-                vehicle_id =
-                    Some(String::from_utf8_lossy(&data).trim().parse().map_err(|_| {
-                        (StatusCode::BAD_REQUEST, "Invalid vehicle_id".to_string())
-                    })?);
-            }
-            _ if name.starts_with("map_") => {
-                mappings_raw.insert(name, String::from_utf8_lossy(&data).to_string());
-            }
-            _ if name.starts_with("col_") => {
-                mappings_raw.insert(name, String::from_utf8_lossy(&data).to_string());
-            }
-            _ => {}
-        }
-    }
+    // Parse import_id as UUID
+    let import_uuid = uuid::Uuid::parse_str(import_id).map_err(|_| {
+        (
+            StatusCode::BAD_REQUEST,
+            "Invalid import_id format".to_string(),
+        )
+    })?;
 
-    let vehicle_id =
-        vehicle_id.ok_or((StatusCode::BAD_REQUEST, "vehicle_id required".to_string()))?;
-    let csv_data = csv_data.ok_or((StatusCode::BAD_REQUEST, "No file uploaded".to_string()))?;
+    // Retrieve CSV data from temp_imports table and verify ownership
+    let conn = pool.get().await.map_err(internal_error)?;
+    let temp_import: crate::models::TempImport = conn
+        .interact(move |conn| {
+            crate::schema::temp_imports::table
+                .filter(crate::schema::temp_imports::id.eq(import_uuid))
+                .filter(crate::schema::temp_imports::user_id.eq(user_id))
+                .first::<crate::models::TempImport>(conn)
+        })
+        .await
+        .map_err(internal_error)?
+        .map_err(|_| {
+            (
+                StatusCode::NOT_FOUND,
+                "Import not found or expired".to_string(),
+            )
+        })?;
 
+    // Build mappings from form data
     let mut actual_mappings: HashMap<String, String> = HashMap::new();
     let mut i = 0;
-    while let Some(col_name) = mappings_raw.get(&format!("col_{}", i)) {
-        if let Some(target_field) = mappings_raw
-            .get(&format!("map_{}", i))
-            .filter(|s| !s.is_empty())
-        {
+    while let Some(col_name) = payload.get(&format!("col_{}", i)) {
+        if let Some(target_field) = payload.get(&format!("map_{}", i)).filter(|s| !s.is_empty()) {
             actual_mappings.insert(target_field.clone(), col_name.clone());
         }
         i += 1;
     }
 
+    // Perform the import
+    let csv_data = temp_import.csv_data;
     let result = perform_import(&pool, user.user_id, vehicle_id, csv_data, actual_mappings).await?;
+
+    // Clean up the temp import after successful/failed execution
+    let import_uuid_clone = import_uuid;
+    let _ = conn
+        .interact(move |conn| {
+            diesel::delete(
+                crate::schema::temp_imports::table
+                    .filter(crate::schema::temp_imports::id.eq(import_uuid_clone)),
+            )
+            .execute(conn)
+        })
+        .await
+        .map_err(internal_error)?;
 
     let template = if result.total_errors > 0 && result.imported == 0 {
         ImportResultTemplate {

--- a/src/models.rs
+++ b/src/models.rs
@@ -127,3 +127,23 @@ pub struct NewVehicleShare {
     pub shared_with_user_id: i32,
     pub permission_level: Option<String>,
 }
+
+#[derive(Queryable, Selectable, serde::Serialize)]
+#[diesel(table_name = crate::schema::temp_imports)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct TempImport {
+    pub id: uuid::Uuid,
+    pub user_id: i32,
+    pub vehicle_id: i32,
+    pub csv_data: Vec<u8>,
+    pub created_at: NaiveDateTime,
+}
+
+#[derive(Insertable, serde::Deserialize)]
+#[diesel(table_name = crate::schema::temp_imports)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct NewTempImport {
+    pub user_id: i32,
+    pub vehicle_id: i32,
+    pub csv_data: Vec<u8>,
+}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -23,6 +23,16 @@ diesel::table! {
 }
 
 diesel::table! {
+    temp_imports (id) {
+        id -> Uuid,
+        user_id -> Int4,
+        vehicle_id -> Int4,
+        csv_data -> Bytea,
+        created_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     users (id) {
         id -> Int4,
         email -> Text,
@@ -57,6 +67,8 @@ diesel::table! {
 diesel::joinable!(fuel_entries -> fuel_stations (station_id));
 diesel::joinable!(fuel_entries -> vehicles (vehicle_id));
 diesel::joinable!(fuel_stations -> users (user_id));
+diesel::joinable!(temp_imports -> users (user_id));
+diesel::joinable!(temp_imports -> vehicles (vehicle_id));
 diesel::joinable!(vehicle_shares -> users (shared_with_user_id));
 diesel::joinable!(vehicle_shares -> vehicles (vehicle_id));
 diesel::joinable!(vehicles -> users (owner_id));
@@ -64,6 +76,7 @@ diesel::joinable!(vehicles -> users (owner_id));
 diesel::allow_tables_to_appear_in_same_query!(
     fuel_entries,
     fuel_stations,
+    temp_imports,
     users,
     vehicle_shares,
     vehicles,

--- a/templates/fragments/import_mapping.html
+++ b/templates/fragments/import_mapping.html
@@ -4,21 +4,10 @@
         Match each CSV column to the corresponding fuel entry field. Required: Date, Litres, Cost, Mileage.
     </p>
 
-    <!-- We need to preserve the vehicle_id and file data, but since we can't easily send the file again in a hidden field, 
-         we might need to store it temporarily on the server or use a different strategy. 
-         For HTMX simplicity, we can use hx-include to include the original file input, 
-         but it's better to use a two-step process where the file is uploaded once.
-    -->
-
-    <form hx-post="/htmx/import/execute" hx-encoding="multipart/form-data" hx-target="#import-container">
+    <form hx-post="/htmx/import/execute" hx-target="#import-container">
         <!-- Hidden inputs to carry forward state -->
+        <input type="hidden" name="import_id" value="{{ import_id }}">
         <input type="hidden" name="vehicle_id" value="{{ vehicle_id }}">
-        
-        <div style="background: var(--bg); padding: 1rem; border-radius: 8px; margin-bottom: 1.5rem; border: 1px solid var(--border);">
-            <p style="margin-top: 0; font-size: 0.8rem; font-weight: 600;">Confirm File Selection</p>
-            <input type="file" name="file" accept=".csv" required style="font-size: 0.8rem;">
-            <p style="margin-bottom: 0; font-size: 0.75rem; color: var(--text-muted);">Please select the same file again to confirm the import.</p>
-        </div>
 
         <table style="width: 100%; border-collapse: collapse; margin-bottom: 1.5rem;">
             <thead>

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -21,7 +21,10 @@ pub async fn create_test_pool() -> Pool {
     let pool = Pool::builder(manager).build().unwrap();
 
     // Run migrations (only needed for first test, diesel tracks which ran)
-    let conn = pool.get().await.expect("Failed to get connection from pool");
+    let conn = pool
+        .get()
+        .await
+        .expect("Failed to get connection from pool");
     let _ = conn
         .interact(|conn| {
             use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -18,7 +18,20 @@ pub async fn create_test_pool() -> Pool {
     let database_url = std::env::var("DATABASE_URL")
         .unwrap_or_else(|_| "postgres://postgres:postgres@localhost:5432/deesl_test".to_string());
     let manager = Manager::new(database_url, deadpool_diesel::Runtime::Tokio1);
-    Pool::builder(manager).build().unwrap()
+    let pool = Pool::builder(manager).build().unwrap();
+
+    // Run migrations (only needed for first test, diesel tracks which ran)
+    let conn = pool.get().await.expect("Failed to get connection from pool");
+    let _ = conn
+        .interact(|conn| {
+            use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
+            const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
+            // Use ignore to avoid panicking if migrations already ran or table exists
+            let _ = conn.run_pending_migrations(MIGRATIONS);
+        })
+        .await;
+
+    pool
 }
 
 /// Creates a test app with the given database pool
@@ -220,5 +233,30 @@ pub async fn post_import_csv(
         .post(path)
         .add_header("Cookie", format!("auth_token={}", token))
         .multipart(form)
+        .await
+}
+
+/// Posts import execute data as form (not multipart, since file is already stored)
+pub async fn post_import_execute(
+    server: &TestServer,
+    token: &str,
+    import_id: &str,
+    vehicle_id: i32,
+    mappings: std::collections::HashMap<String, String>,
+) -> TestResponse {
+    use std::collections::HashMap;
+
+    let mut form_data: HashMap<String, String> = HashMap::new();
+    form_data.insert("import_id".to_string(), import_id.to_string());
+    form_data.insert("vehicle_id".to_string(), vehicle_id.to_string());
+
+    for (k, v) in mappings {
+        form_data.insert(k, v);
+    }
+
+    server
+        .post("/htmx/import/execute")
+        .add_header("Cookie", format!("auth_token={}", token))
+        .form(&form_data)
         .await
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -266,14 +266,9 @@ async fn test_htmx_import_execute() {
     mappings.insert("col_3".to_string(), "Mileage".to_string());
     mappings.insert("map_3".to_string(), "mileage_km".to_string());
 
-    let response = common::post_import_execute(
-        &env.server,
-        &user.token,
-        import_id,
-        vehicle_id,
-        mappings,
-    )
-    .await;
+    let response =
+        common::post_import_execute(&env.server, &user.token, import_id, vehicle_id, mappings)
+            .await;
 
     response.assert_status_ok();
     assert!(response.text().contains("Import Successful"));

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -231,6 +231,31 @@ async fn test_htmx_import_execute() {
         common::create_test_vehicle_db(&env.pool, user.id, "Import", "Car", "IMP-2").await;
 
     let csv_content = b"Date,Litres,Cost,Mileage\n2024-03-01,40.5,60.0,10000";
+
+    // Step 1: Call preview to store CSV and get import_id
+    let preview_response = common::post_import_csv(
+        &env.server,
+        "/htmx/import/preview",
+        &user.token,
+        vehicle_id,
+        csv_content,
+        None,
+    )
+    .await;
+
+    preview_response.assert_status_ok();
+    let preview_html = preview_response.text();
+
+    // Extract import_id from the HTML (it's in a hidden input field)
+    let import_id = preview_html
+        .split("name=\"import_id\" value=\"")
+        .nth(1)
+        .unwrap()
+        .split("\"")
+        .next()
+        .unwrap();
+
+    // Step 2: Call execute with import_id and mappings
     let mut mappings = std::collections::HashMap::new();
     mappings.insert("col_0".to_string(), "Date".to_string());
     mappings.insert("map_0".to_string(), "filled_at_date".to_string());
@@ -241,13 +266,12 @@ async fn test_htmx_import_execute() {
     mappings.insert("col_3".to_string(), "Mileage".to_string());
     mappings.insert("map_3".to_string(), "mileage_km".to_string());
 
-    let response = common::post_import_csv(
+    let response = common::post_import_execute(
         &env.server,
-        "/htmx/import/execute",
         &user.token,
+        import_id,
         vehicle_id,
-        csv_content,
-        Some(mappings),
+        mappings,
     )
     .await;
 


### PR DESCRIPTION
Closes #29

Implements two-step import process where CSV data is stored temporarily
between preview and execute steps, eliminating the need for users to
re-upload the same file twice.

Key changes:
- New temp_imports table stores CSV data with 1-hour TTL
- Import preview now generates UUID and stores file server-side
- Import execute retrieves file by UUID instead of re-upload
- Removed file re-upload requirement from mapping interface