### PR TITLE
Fuzzy search for station selection

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,7 +1,7 @@
 use askama::Template;
 use axum::{
     Form,
-    extract::{Multipart, State},
+    extract::{Multipart, Query, State},
     http::{HeaderMap, StatusCode},
     response::{Html, IntoResponse, Redirect},
 };
@@ -832,12 +832,86 @@ pub async fn htmx_recent_entries(
 }
 
 #[derive(Template)]
+#[template(path = "fragments/station_search_results.html")]
+pub struct StationSearchResultsTemplate {
+    pub stations: Vec<FuelStation>,
+    pub query: String,
+}
+
+pub async fn htmx_station_search(
+    State(pool): State<Pool>,
+    user: AuthUser,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let query = params.get("q").cloned().unwrap_or_default();
+    let query_lower = query.to_lowercase();
+
+    if query.len() < 2 {
+        return Ok(Html(String::new()));
+    }
+
+    let conn = pool.get().await.map_err(internal_error)?;
+    let user_id = user.user_id;
+
+    // Fetch all stations for the user (user's own + global)
+    let stations: Vec<FuelStation> = conn
+        .interact(move |conn| {
+            fuel_stations::table
+                .filter(
+                    fuel_stations::user_id
+                        .eq(user_id)
+                        .or(fuel_stations::user_id.is_null()),
+                )
+                .order(fuel_stations::name)
+                .load::<FuelStation>(conn)
+        })
+        .await
+        .map_err(internal_error)?
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    // Filter stations by fuzzy matching
+    let filtered_stations: Vec<FuelStation> = stations
+        .into_iter()
+        .filter(|s| {
+            let name_lower = s.name.to_lowercase();
+            // Check if query is a substring (case-insensitive)
+            name_lower.contains(&query_lower) ||
+            // Or if all query characters appear in order
+            fuzzy_match(&name_lower, &query_lower)
+        })
+        .take(10) // Limit to 10 results
+        .collect();
+
+    let template = StationSearchResultsTemplate {
+        stations: filtered_stations,
+        query,
+    };
+    Ok(Html(template.render().map_err(internal_error)?))
+}
+
+/// Simple fuzzy matching - checks if all characters in query appear in name in order
+fn fuzzy_match(name: &str, query: &str) -> bool {
+    let mut name_chars = name.chars();
+    for query_char in query.chars() {
+        loop {
+            match name_chars.next() {
+                Some(name_char) if name_char == query_char => break,
+                None => return false,
+                _ => continue,
+            }
+        }
+    }
+    true
+}
+
+#[derive(Template)]
 #[template(path = "edit_fuel_entry.html")]
 pub struct EditFuelEntryTemplate {
     pub logged_in: bool,
     pub entry: FuelEntry,
     pub vehicle: Vehicle,
     pub stations: Vec<FuelStation>,
+    pub current_station_name: String,
     pub filled_at_formatted: String,
 }
 
@@ -879,11 +953,19 @@ pub async fn edit_fuel_entry(
 
     let filled_at_formatted = entry.filled_at.format("%Y-%m-%dT%H:%M").to_string();
 
+    // Find the current station name
+    let current_station_name = entry
+        .station_id
+        .and_then(|id| stations.iter().find(|s| s.id == id))
+        .map(|s| s.name.clone())
+        .unwrap_or_default();
+
     let template = EditFuelEntryTemplate {
         logged_in: true,
         entry,
         vehicle,
         stations,
+        current_station_name,
         filled_at_formatted,
     };
     Ok(Html(template.render().map_err(internal_error)?))

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -797,7 +797,7 @@ pub async fn htmx_delete_vehicle(
 #[derive(Template)]
 #[template(path = "fragments/recent_entries.html")]
 pub struct RecentEntriesTemplate {
-    pub entries: Vec<(crate::models::FuelEntry, Vehicle)>,
+    pub entries: Vec<(crate::models::FuelEntry, Vehicle, Option<FuelStation>)>,
 }
 
 impl RecentEntriesTemplate {
@@ -813,15 +813,20 @@ pub async fn htmx_recent_entries(
     let conn = pool.get().await.map_err(internal_error)?;
     let user_id = user.user_id;
 
-    let entries: Vec<(crate::models::FuelEntry, Vehicle)> = conn
+    let entries: Vec<(crate::models::FuelEntry, Vehicle, Option<FuelStation>)> = conn
         .interact(move |conn| {
             crate::schema::fuel_entries::table
                 .inner_join(vehicles::table)
+                .left_join(crate::schema::fuel_stations::table)
                 .filter(vehicles::owner_id.eq(user_id))
                 .order(crate::schema::fuel_entries::filled_at.desc())
                 .limit(5)
-                .select((crate::models::FuelEntry::as_select(), Vehicle::as_select()))
-                .load::<(crate::models::FuelEntry, Vehicle)>(conn)
+                .select((
+                    crate::models::FuelEntry::as_select(),
+                    Vehicle::as_select(),
+                    Option::<FuelStation>::as_select(),
+                ))
+                .load::<(crate::models::FuelEntry, Vehicle, Option<FuelStation>)>(conn)
         })
         .await
         .map_err(internal_error)?

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,6 +147,7 @@ async fn main() {
         .route("/htmx/vehicles", get(handlers::htmx_vehicles))
         .route("/htmx/vehicles/{id}", delete(handlers::htmx_delete_vehicle))
         .route("/htmx/entries/recent", get(handlers::htmx_recent_entries))
+        .route("/htmx/stations/search", get(handlers::htmx_station_search))
         .route("/api/version", get(serve_version))
         .merge(oauth_handlers::router())
         .layer(TraceLayer::new_for_http())

--- a/templates/add_fuel_entry.html
+++ b/templates/add_fuel_entry.html
@@ -18,13 +18,24 @@
             </select>
         </div>
 
-        <div class="form-group">
-            <label for="station">Station</label>
-            <select id="station" name="station_id" required>
-                {% for station in stations %}
-                <option value="{{ station.id }}">{{ station.name }}</option>
-                {% endfor %}
-            </select>
+        <div class="form-group" style="position: relative;">
+            <label for="station_search">Station</label>
+            <input type="hidden" id="station_id" name="station_id" required>
+            <input type="text" 
+                   id="station_search" 
+                   name="q"
+                   placeholder="Type to search stations..." 
+                   autocomplete="off"
+                   hx-get="/htmx/stations/search"
+                   hx-trigger="keyup changed delay:200ms, focus"
+                   hx-target="#station_results"
+                   hx-indicator="#station-spinner"
+                   style="width: 100%;"
+                   oninput="document.getElementById('station_id').value = ''">
+            <div id="station-spinner" class="htmx-indicator spinner" style="position: absolute; right: 0.75rem; top: 2.25rem;"></div>
+            <div id="station_results" 
+                 style="position: absolute; top: 100%; left: 0; right: 0; background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm); box-shadow: var(--shadow); z-index: 100; max-height: 200px; overflow-y: auto;">
+            </div>
         </div>
 
         <div class="form-group">
@@ -53,4 +64,15 @@
         </div>
     </form>
 </div>
+
+<script>
+// Close station results when clicking outside
+document.addEventListener('click', function(e) {
+    const container = document.querySelector('.form-group[style*="position: relative"]');
+    const results = document.getElementById('station_results');
+    if (container && results && !container.contains(e.target)) {
+        results.innerHTML = '';
+    }
+});
+</script>
 {% endblock %}

--- a/templates/edit_fuel_entry.html
+++ b/templates/edit_fuel_entry.html
@@ -14,13 +14,25 @@
             <input type="text" value="{{ vehicle.make }} {{ vehicle.model }} ({{ vehicle.registration }})" disabled style="background: var(--surface-hover);">
         </div>
 
-        <div class="form-group">
-            <label for="station">Station</label>
-            <select id="station" name="station_id" required>
-                {% for station in stations %}
-                <option value="{{ station.id }}" {% if entry.station_id.is_some() && entry.station_id.unwrap() == station.id %}selected{% endif %}>{{ station.name }}</option>
-                {% endfor %}
-            </select>
+        <div class="form-group" style="position: relative;">
+            <label for="station_search">Station</label>
+            <input type="hidden" id="station_id" name="station_id" value="{{ entry.station_id.unwrap_or(0) }}" required>
+            <input type="text" 
+                   id="station_search" 
+                   name="q"
+                   placeholder="Type to search stations..." 
+                   autocomplete="off"
+                   hx-get="/htmx/stations/search"
+                   hx-trigger="keyup changed delay:200ms, focus"
+                   hx-target="#station_results"
+                   hx-indicator="#station-spinner"
+                   value="{{ current_station_name }}"
+                   style="width: 100%;"
+                   oninput="document.getElementById('station_id').value = ''">
+            <div id="station-spinner" class="htmx-indicator spinner" style="position: absolute; right: 0.75rem; top: 2.25rem;"></div>
+            <div id="station_results" 
+                 style="position: absolute; top: 100%; left: 0; right: 0; background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm); box-shadow: var(--shadow); z-index: 100; max-height: 200px; overflow-y: auto;">
+            </div>
         </div>
 
         <div class="form-group">
@@ -49,4 +61,15 @@
         </div>
     </form>
 </div>
+
+<script>
+// Close station results when clicking outside
+document.addEventListener('click', function(e) {
+    const container = document.querySelector('.form-group[style*="position: relative"]');
+    const results = document.getElementById('station_results');
+    if (container && results && !container.contains(e.target)) {
+        results.innerHTML = '';
+    }
+});
+</script>
 {% endblock %}

--- a/templates/fragments/recent_entries.html
+++ b/templates/fragments/recent_entries.html
@@ -10,16 +10,24 @@
                 <tr>
                     <th>Date</th>
                     <th>Vehicle</th>
+                    <th>Station</th>
                     <th>Litres</th>
                     <th>Cost</th>
                     <th style="text-align: right;">Actions</th>
                 </tr>
             </thead>
             <tbody>
-                {% for (e, v) in entries %}
+                {% for (e, v, s) in entries %}
                 <tr>
                     <td>{{ e.filled_at.format("%Y-%m-%d") }}</td>
                     <td>{{ v.registration }}</td>
+                    <td>
+                        {% if s.is_some() %}
+                            {{ s.as_ref().unwrap().name }}
+                        {% else %}
+                            <span style="color: var(--text-muted); font-style: italic;">Unknown</span>
+                        {% endif %}
+                    </td>
                     <td>{{ self.format_float(e.litres) }} L</td>
                     <td>€{{ self.format_float(e.cost) }}</td>
                     <td style="text-align: right;">

--- a/templates/fragments/station_search_results.html
+++ b/templates/fragments/station_search_results.html
@@ -1,0 +1,30 @@
+{% if stations.is_empty() %}
+    <div style="padding: 0.75rem; color: var(--text-muted); font-size: 0.875rem;">
+        No stations found matching "{{ query }}"
+    </div>
+{% else %}
+    {% for station in stations %}
+        <div class="station-result" 
+             style="padding: 0.75rem; cursor: pointer; border-bottom: 1px solid var(--border); transition: background 0.15s ease;"
+             onmouseover="this.style.background='var(--surface-hover)'"
+             onmouseout="this.style.background='transparent'"
+             onclick="selectStation('{{ station.id }}', '{{ station.name }}')">
+            <div style="font-weight: 500; color: var(--text);">{{ station.name }}</div>
+            {% if station.user_id.is_none() %}
+                <div style="font-size: 0.75rem; color: var(--text-muted);">System station</div>
+            {% endif %}
+        </div>
+    {% endfor %}
+{% endif %}
+
+<script>
+function selectStation(id, name) {
+    const hiddenInput = document.getElementById('station_id');
+    const textInput = document.getElementById('station_search');
+    const results = document.getElementById('station_results');
+    
+    if (hiddenInput) hiddenInput.value = id;
+    if (textInput) textInput.value = name;
+    if (results) results.innerHTML = '';
+}
+</script>

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -82,6 +82,7 @@ pub async fn create_test_app(pool: Pool) -> Router {
         .route("/htmx/vehicles", get(handlers::htmx_vehicles))
         .route("/htmx/vehicles/{id}", delete(handlers::htmx_delete_vehicle))
         .route("/htmx/entries/recent", get(handlers::htmx_recent_entries))
+        .route("/htmx/stations/search", get(handlers::htmx_station_search))
         .merge(oauth_handlers::router())
         .layer(TraceLayer::new_for_http())
         .with_state(app_state)


### PR DESCRIPTION
Adds autocomplete fuzzy search for selecting fuel stations in fuel entry forms, replacing the long dropdown list.

Features:
- Real-time fuzzy text matching as you type
- Shows up to 10 matching stations
- Minimum 2 characters required to search
- Displays system vs user stations
- Pre-populates current station when editing