### PR TITLE
feat: implement unified error handling with AppError enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "askama"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,7 +75,18 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
 dependencies = [
- "nom",
+ "nom 7.1.3",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -133,7 +150,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
- "tokio",
+ "tokio 1.49.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -206,7 +223,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "tokio",
+ "tokio 1.49.0",
  "tower",
  "url",
 ]
@@ -347,6 +364,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
+dependencies = [
+ "lazy_static",
+ "nom 5.1.3",
+ "serde",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +419,21 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -460,6 +503,20 @@ dependencies = [
 
 [[package]]
 name = "deadpool"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1ea999b4bd6f33b668ea6c847823fc95105be8799c0cf3611ac4025871e004"
+dependencies = [
+ "async-trait",
+ "config",
+ "crossbeam-queue",
+ "num_cpus",
+ "serde",
+ "tokio 0.3.7",
+]
+
+[[package]]
+name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
@@ -467,7 +524,7 @@ dependencies = [
  "deadpool-runtime",
  "lazy_static",
  "num_cpus",
- "tokio",
+ "tokio 1.49.0",
 ]
 
 [[package]]
@@ -476,7 +533,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "590573e9e29c5190a5ff782136f871e6e652e35d598a349888e028693601adf1"
 dependencies = [
- "deadpool",
+ "deadpool 0.12.3",
  "deadpool-sync",
  "diesel",
 ]
@@ -487,7 +544,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 dependencies = [
- "tokio",
+ "tokio 1.49.0",
 ]
 
 [[package]]
@@ -501,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "deesl"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "askama",
  "axum",
@@ -509,6 +566,7 @@ dependencies = [
  "axum-test",
  "chrono",
  "csv",
+ "deadpool 0.6.0",
  "deadpool-diesel",
  "diesel",
  "diesel_migrations",
@@ -523,7 +581,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
- "tokio",
+ "tokio 1.49.0",
  "tokio-util",
  "tower",
  "tower-cookies",
@@ -891,7 +949,7 @@ dependencies = [
  "http 0.2.12",
  "indexmap",
  "slab",
- "tokio",
+ "tokio 1.49.0",
  "tokio-util",
  "tracing",
 ]
@@ -910,7 +968,7 @@ dependencies = [
  "http 1.4.0",
  "indexmap",
  "slab",
- "tokio",
+ "tokio 1.49.0",
  "tokio-util",
  "tracing",
 ]
@@ -1079,7 +1137,7 @@ dependencies = [
  "itoa",
  "pin-project-lite",
  "socket2 0.5.10",
- "tokio",
+ "tokio 1.49.0",
  "tower-service",
  "tracing",
  "want",
@@ -1104,7 +1162,7 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "smallvec",
- "tokio",
+ "tokio 1.49.0",
  "want",
 ]
 
@@ -1118,7 +1176,7 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.32",
  "rustls 0.21.12",
- "tokio",
+ "tokio 1.49.0",
  "tokio-rustls 0.24.1",
 ]
 
@@ -1133,7 +1191,7 @@ dependencies = [
  "hyper-util",
  "rustls 0.23.37",
  "rustls-pki-types",
- "tokio",
+ "tokio 1.49.0",
  "tokio-rustls 0.26.4",
  "tower-service",
 ]
@@ -1157,7 +1215,7 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.6.2",
  "system-configuration 0.7.0",
- "tokio",
+ "tokio 1.49.0",
  "tower-service",
  "tracing",
  "windows-registry",
@@ -1414,6 +1472,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,6 +1603,17 @@ dependencies = [
  "memchr",
  "mime",
  "spin",
+ "version_check",
+]
+
+[[package]]
+name = "nom"
+version = "5.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
+dependencies = [
+ "lexical-core",
+ "memchr",
  "version_check",
 ]
 
@@ -1820,7 +1902,7 @@ dependencies = [
  "rustls 0.23.37",
  "socket2 0.6.2",
  "thiserror 2.0.18",
- "tokio",
+ "tokio 1.49.0",
  "tracing",
  "web-time",
 ]
@@ -2009,7 +2091,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
  "system-configuration 0.5.1",
- "tokio",
+ "tokio 1.49.0",
  "tokio-rustls 0.24.1",
  "tower-service",
  "url",
@@ -2049,7 +2131,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sync_wrapper 1.0.2",
- "tokio",
+ "tokio 1.49.0",
  "tokio-rustls 0.26.4",
  "tower",
  "tower-http",
@@ -2493,6 +2575,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,6 +2778,16 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46409491c9375a693ce7032101970a54f8a2010efb77e13f70788f0d84489e39"
+dependencies = [
+ "autocfg",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
@@ -2721,7 +2819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls 0.21.12",
- "tokio",
+ "tokio 1.49.0",
 ]
 
 [[package]]
@@ -2731,7 +2829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls 0.23.37",
- "tokio",
+ "tokio 1.49.0",
 ]
 
 [[package]]
@@ -2744,7 +2842,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
- "tokio",
+ "tokio 1.49.0",
 ]
 
 [[package]]
@@ -2800,7 +2898,7 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper 1.0.2",
- "tokio",
+ "tokio 1.49.0",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2842,7 +2940,7 @@ dependencies = [
  "mime_guess",
  "percent-encoding",
  "pin-project-lite",
- "tokio",
+ "tokio 1.49.0",
  "tokio-util",
  "tower",
  "tower-layer",
@@ -2866,7 +2964,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "pin-project-lite",
- "tokio",
+ "tokio 1.49.0",
  "tower",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deesl"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 
 [lib]
@@ -17,6 +17,7 @@ axum = { version = "0.8.8", features = ["json", "tokio", "form", "multipart"] }
 axum-extra = { version = "0.10", features = ["typed-header"] }
 chrono = { version = "0.4.44", features = ["serde"] }
 csv = "1.4"
+deadpool = "0.6"
 deadpool-diesel = { version = "0.6.1", features = ["postgres"] }
 diesel = { version = "2.3.6", features = ["postgres", "chrono", "uuid"] }
 diesel_migrations = { version = "2.2.0", features = ["postgres"] }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::{FromRef, FromRequestParts},
-    http::{HeaderMap, StatusCode, request::Parts},
+    http::{HeaderMap, request::Parts},
     response::Redirect,
 };
 use deadpool_diesel::postgres::Pool;
@@ -8,7 +8,7 @@ use diesel::prelude::*;
 use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation, decode, encode};
 use serde::{Deserialize, Serialize};
 
-use crate::handlers::internal_error;
+use crate::error::AppError;
 use crate::oauth_handlers::extract_cookie;
 use crate::schema::users;
 
@@ -91,7 +91,7 @@ where
     Pool: FromRef<S>,
     S: Send + Sync,
 {
-    type Rejection = (StatusCode, String);
+    type Rejection = AppError;
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         let auth_config = AuthConfig::from_ref(state);
@@ -135,22 +135,20 @@ pub async fn extract_auth_user(
     headers: &HeaderMap,
     auth_config: &AuthConfig,
     pool: &Pool,
-) -> Result<AuthUser, (StatusCode, String)> {
-    // Dev bypass for local testing - simplified: just set DEV_AUTH_EMAIL
+) -> Result<AuthUser, AppError> {
     if let Some(email) = is_dev_auth_bypass_allowed(headers) {
         return Ok(AuthUser { user_id: 1, email });
     }
 
     let token = extract_cookie(headers, "auth_token")
-        .ok_or((StatusCode::UNAUTHORIZED, "Missing auth token".to_string()))?;
+        .ok_or_else(|| AppError::Unauthorized("Missing auth token".to_string()))?;
 
     let claims = auth_config
         .validate_token(&token)
-        .map_err(|_| (StatusCode::UNAUTHORIZED, "Invalid token".to_string()))?;
+        .map_err(|_| AppError::Unauthorized("Invalid token".to_string()))?;
 
-    // Security hardening: verify user still exists in DB
     let user_id = claims.user_id;
-    let conn = pool.get().await.map_err(internal_error)?;
+    let conn = pool.get().await?;
     let user_exists = conn
         .interact(move |conn| {
             users::table
@@ -159,16 +157,11 @@ pub async fn extract_auth_user(
                 .first::<i32>(conn)
                 .optional()
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .await??
         .is_some();
 
     if !user_exists {
-        return Err((
-            StatusCode::UNAUTHORIZED,
-            "User no longer exists".to_string(),
-        ));
+        return Err(AppError::Unauthorized("User no longer exists".to_string()));
     }
 
     Ok(AuthUser {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,10 +1,10 @@
 use axum::{
     extract::{FromRef, FromRequestParts},
-    http::{StatusCode, request::Parts},
+    http::request::Parts,
 };
 use deadpool_diesel::postgres::{Object, Pool};
 
-use crate::handlers::internal_error;
+use crate::error::AppError;
 
 /// Custom extractor for database connections.
 /// This simplifies handlers by removing the need to manually call `pool.get().await`.
@@ -15,11 +15,11 @@ where
     Pool: FromRef<S>,
     S: Send + Sync,
 {
-    type Rejection = (StatusCode, String);
+    type Rejection = AppError;
 
     async fn from_request_parts(_parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         let pool = Pool::from_ref(state);
-        let conn = pool.get().await.map_err(internal_error)?;
+        let conn = pool.get().await?;
         Ok(DbConn(conn))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,126 @@
+use axum::extract::multipart::MultipartError;
+use axum::{
+    http::StatusCode,
+    response::{Html, IntoResponse},
+};
+use deadpool_diesel::{InteractError as DeadpoolInteractError, PoolError};
+use diesel::result::Error as DieselError;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum AppError {
+    NotFound(String),
+    BadRequest(String),
+    Unauthorized(String),
+    Forbidden(String),
+    Internal(String),
+    Database(DatabaseError),
+}
+
+#[derive(Debug)]
+pub enum DatabaseError {
+    NotFound,
+    UniqueViolation(String),
+    ForeignKeyViolation(String),
+    Other(String),
+}
+
+impl fmt::Display for AppError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AppError::NotFound(msg) => write!(f, "{}", msg),
+            AppError::BadRequest(msg) => write!(f, "{}", msg),
+            AppError::Unauthorized(msg) => write!(f, "{}", msg),
+            AppError::Forbidden(msg) => write!(f, "{}", msg),
+            AppError::Internal(msg) => write!(f, "{}", msg),
+            AppError::Database(err) => write!(f, "{}", err),
+        }
+    }
+}
+
+impl fmt::Display for DatabaseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DatabaseError::NotFound => write!(f, "Record not found"),
+            DatabaseError::UniqueViolation(msg) => write!(f, "{}", msg),
+            DatabaseError::ForeignKeyViolation(msg) => write!(f, "{}", msg),
+            DatabaseError::Other(msg) => write!(f, "{}", msg),
+        }
+    }
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> axum::response::Response {
+        let (status, message) = match &self {
+            AppError::NotFound(msg) => (StatusCode::NOT_FOUND, msg.clone()),
+            AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
+            AppError::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg.clone()),
+            AppError::Forbidden(msg) => (StatusCode::FORBIDDEN, msg.clone()),
+            AppError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg.clone()),
+            AppError::Database(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
+        };
+
+        tracing::error!("Error: {:?}", self);
+
+        let body = format!(
+            r#"<!DOCTYPE html>
+<html>
+<head><title>{}</title></head>
+<body>
+<h1>{}</h1>
+<p>{}</p>
+</body>
+</html>"#,
+            status.canonical_reason().unwrap_or("Error"),
+            status.canonical_reason().unwrap_or("Error"),
+            message
+        );
+
+        (status, Html(body)).into_response()
+    }
+}
+
+impl From<PoolError> for AppError {
+    fn from(err: PoolError) -> Self {
+        AppError::Internal(err.to_string())
+    }
+}
+
+impl From<DeadpoolInteractError> for AppError {
+    fn from(err: DeadpoolInteractError) -> Self {
+        AppError::Internal(err.to_string())
+    }
+}
+
+impl From<DieselError> for AppError {
+    fn from(err: DieselError) -> Self {
+        match err {
+            DieselError::NotFound => AppError::Database(DatabaseError::NotFound),
+            DieselError::DatabaseError(kind, info) => {
+                let msg = info.message().to_string();
+                match kind {
+                    diesel::result::DatabaseErrorKind::UniqueViolation => {
+                        AppError::Database(DatabaseError::UniqueViolation(msg))
+                    }
+                    diesel::result::DatabaseErrorKind::ForeignKeyViolation => {
+                        AppError::Database(DatabaseError::ForeignKeyViolation(msg))
+                    }
+                    _ => AppError::Database(DatabaseError::Other(msg)),
+                }
+            }
+            _ => AppError::Internal(err.to_string()),
+        }
+    }
+}
+
+impl From<askama::Error> for AppError {
+    fn from(err: askama::Error) -> Self {
+        AppError::Internal(err.to_string())
+    }
+}
+
+impl From<MultipartError> for AppError {
+    fn from(err: MultipartError) -> Self {
+        AppError::Internal(err.to_string())
+    }
+}

--- a/src/handlers/fuel_entries.rs
+++ b/src/handlers/fuel_entries.rs
@@ -2,7 +2,6 @@ use askama::Template;
 use axum::{
     Form, Router,
     extract::Query,
-    http::StatusCode,
     response::{Html, IntoResponse},
     routing::{delete, get, post},
 };
@@ -10,10 +9,11 @@ use diesel::prelude::*;
 use serde::Deserialize;
 use std::collections::HashMap;
 
-use super::{HxRedirect, check_vehicle_write_access, internal_error};
+use super::{HxRedirect, check_vehicle_write_access};
 use crate::AppState;
 use crate::auth::{AuthUser, AuthUserRedirect};
 use crate::db::DbConn;
+use crate::error::AppError;
 use crate::models::{FuelEntry, FuelStation, User, Vehicle};
 use crate::schema::{fuel_stations, users, vehicles};
 
@@ -41,7 +41,7 @@ pub struct AddFuelEntryTemplate {
 pub async fn new_fuel_entry(
     DbConn(conn): DbConn,
     AuthUserRedirect(user): AuthUserRedirect,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     let user_id = user.user_id;
 
     let (user_vehicles, user_stations, db_user): (Vec<Vehicle>, Vec<FuelStation>, User) = conn
@@ -61,13 +61,9 @@ pub async fn new_fuel_entry(
             let db_user = users::table
                 .filter(users::id.eq(user_id))
                 .first::<User>(conn)?;
-            Ok::<(Vec<Vehicle>, Vec<FuelStation>, User), diesel::result::Error>((
-                vehicles, stations, db_user,
-            ))
+            Ok::<_, diesel::result::Error>((vehicles, stations, db_user))
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .await??;
 
     let template = AddFuelEntryTemplate {
         logged_in: true,
@@ -77,7 +73,7 @@ pub async fn new_fuel_entry(
         distance_unit: db_user.distance_unit,
         volume_unit: db_user.volume_unit,
     };
-    Ok(Html(template.render().map_err(internal_error)?))
+    Ok(Html(template.render()?))
 }
 
 #[derive(Deserialize)]
@@ -94,7 +90,7 @@ pub async fn create_fuel_entry(
     DbConn(conn): DbConn,
     user: AuthUser,
     Form(payload): Form<CreateFuelEntryForm>,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     let vehicle_id = payload.vehicle_id;
 
     check_vehicle_write_access(&conn, user.user_id, vehicle_id).await?;
@@ -115,9 +111,7 @@ pub async fn create_fuel_entry(
             })
             .execute(conn)
     })
-    .await
-    .map_err(internal_error)?
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    .await??;
 
     Ok(HxRedirect("/dashboard"))
 }
@@ -126,11 +120,10 @@ pub async fn htmx_delete_fuel_entry(
     DbConn(conn): DbConn,
     user: AuthUser,
     axum::extract::Path(id): axum::extract::Path<i32>,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     let user_id = user.user_id;
 
-    // First check if entry exists and get vehicle_id
-    let vehicle_id: i32 = conn
+    let vehicle_id = conn
         .interact(move |conn| {
             crate::schema::fuel_entries::table
                 .filter(crate::schema::fuel_entries::id.eq(id))
@@ -138,23 +131,18 @@ pub async fn htmx_delete_fuel_entry(
                 .first::<i32>(conn)
                 .optional()
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or((StatusCode::NOT_FOUND, "Entry not found".to_string()))?;
+        .await??
+        .ok_or_else(|| AppError::NotFound("Entry not found".to_string()))?;
 
     check_vehicle_write_access(&conn, user_id, vehicle_id).await?;
 
-    // Delete the entry
     conn.interact(move |conn| {
         diesel::delete(
             crate::schema::fuel_entries::table.filter(crate::schema::fuel_entries::id.eq(id)),
         )
         .execute(conn)
     })
-    .await
-    .map_err(internal_error)?
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    .await??;
 
     Ok(Html(""))
 }
@@ -176,7 +164,7 @@ impl RecentEntriesTemplate {
 pub async fn htmx_recent_entries(
     DbConn(conn): DbConn,
     user: AuthUser,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     let user_id = user.user_id;
 
     let (entries, db_user): (
@@ -199,24 +187,16 @@ pub async fn htmx_recent_entries(
             let db_user = users::table
                 .filter(users::id.eq(user_id))
                 .first::<User>(conn)?;
-            Ok::<
-                (
-                    Vec<(crate::models::FuelEntry, Vehicle, Option<FuelStation>)>,
-                    User,
-                ),
-                diesel::result::Error,
-            >((entries, db_user))
+            Ok::<_, diesel::result::Error>((entries, db_user))
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .await??;
 
     let template = RecentEntriesTemplate {
         entries,
         distance_unit: db_user.distance_unit,
         volume_unit: db_user.volume_unit,
     };
-    Ok(Html(template.render().map_err(internal_error)?))
+    Ok(Html(template.render()?))
 }
 
 #[derive(Template)]
@@ -236,7 +216,7 @@ pub async fn edit_fuel_entry(
     DbConn(conn): DbConn,
     AuthUserRedirect(user): AuthUserRedirect,
     axum::extract::Path(entry_id): axum::extract::Path<i32>,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     let user_id = user.user_id;
 
     let (result, stations, db_user): (Option<(FuelEntry, Vehicle)>, Vec<FuelStation>, User) = conn
@@ -258,23 +238,17 @@ pub async fn edit_fuel_entry(
             let db_user = users::table
                 .filter(users::id.eq(user_id))
                 .first::<User>(conn)?;
-            Ok::<(Option<(FuelEntry, Vehicle)>, Vec<FuelStation>, User), diesel::result::Error>((
-                entry_result,
-                stations,
-                db_user,
-            ))
+            Ok::<_, diesel::result::Error>((entry_result, stations, db_user))
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .await??;
 
-    let (entry, vehicle) = result.ok_or((StatusCode::NOT_FOUND, "Entry not found".to_string()))?;
+    let (entry, vehicle) =
+        result.ok_or_else(|| AppError::NotFound("Entry not found".to_string()))?;
 
     check_vehicle_write_access(&conn, user_id, vehicle.id).await?;
 
     let filled_at_formatted = entry.filled_at.format("%Y-%m-%dT%H:%M").to_string();
 
-    // Find the current station name
     let current_station_name = entry
         .station_id
         .and_then(|id| stations.iter().find(|s| s.id == id))
@@ -291,7 +265,7 @@ pub async fn edit_fuel_entry(
         distance_unit: db_user.distance_unit,
         volume_unit: db_user.volume_unit,
     };
-    Ok(Html(template.render().map_err(internal_error)?))
+    Ok(Html(template.render()?))
 }
 
 #[derive(Deserialize)]
@@ -308,10 +282,10 @@ pub async fn update_fuel_entry(
     user: AuthUser,
     axum::extract::Path(entry_id): axum::extract::Path<i32>,
     Form(payload): Form<UpdateFuelEntryForm>,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     let user_id = user.user_id;
 
-    let vehicle_id: i32 = conn
+    let vehicle_id = conn
         .interact(move |conn| {
             crate::schema::fuel_entries::table
                 .filter(crate::schema::fuel_entries::id.eq(entry_id))
@@ -319,15 +293,13 @@ pub async fn update_fuel_entry(
                 .first::<i32>(conn)
                 .optional()
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or((StatusCode::NOT_FOUND, "Entry not found".to_string()))?;
+        .await??
+        .ok_or_else(|| AppError::NotFound("Entry not found".to_string()))?;
 
     check_vehicle_write_access(&conn, user_id, vehicle_id).await?;
 
     let filled_at = chrono::NaiveDateTime::parse_from_str(&payload.filled_at, "%Y-%m-%dT%H:%M")
-        .map_err(|_| (StatusCode::BAD_REQUEST, "Invalid date format".to_string()))?;
+        .map_err(|_| AppError::BadRequest("Invalid date format".to_string()))?;
 
     conn.interact(move |conn| {
         diesel::update(
@@ -342,9 +314,7 @@ pub async fn update_fuel_entry(
         })
         .execute(conn)
     })
-    .await
-    .map_err(internal_error)?
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    .await??;
 
     Ok(HxRedirect("/dashboard"))
 }
@@ -371,16 +341,14 @@ pub async fn fuel_entries_page(
     DbConn(conn): DbConn,
     AuthUserRedirect(user): AuthUserRedirect,
     Query(params): Query<HashMap<String, String>>,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     let user_id = user.user_id;
 
-    // Parse filter parameters
     let filter_vehicle_id = params.get("vehicle_id").and_then(|v| v.parse::<i32>().ok());
     let filter_station_id = params.get("station_id").and_then(|v| v.parse::<i32>().ok());
     let filter_date_from = params.get("date_from").cloned().unwrap_or_default();
     let filter_date_to = params.get("date_to").cloned().unwrap_or_default();
 
-    // Fetch all vehicles for the user (for filter dropdown)
     let vehicles: Vec<Vehicle> = conn
         .interact(move |conn| {
             vehicles::table
@@ -388,11 +356,8 @@ pub async fn fuel_entries_page(
                 .order(vehicles::registration)
                 .load::<Vehicle>(conn)
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .await??;
 
-    // Fetch all stations for the user (for filter dropdown)
     let stations: Vec<FuelStation> = conn
         .interact(move |conn| {
             fuel_stations::table
@@ -404,26 +369,19 @@ pub async fn fuel_entries_page(
                 .order(fuel_stations::name)
                 .load::<FuelStation>(conn)
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .await??;
 
-    // Fetch user for unit preferences
     let db_user: User = conn
         .interact(move |conn| {
             users::table
                 .filter(users::id.eq(user_id))
                 .first::<User>(conn)
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .await??;
 
-    // Clone date filters for the closure
     let filter_date_from_clone = filter_date_from.clone();
     let filter_date_to_clone = filter_date_to.clone();
 
-    // Fetch fuel entries with filters
     let entries: Vec<(crate::models::FuelEntry, Vehicle, Option<FuelStation>)> = conn
         .interact(move |conn| {
             let mut query = crate::schema::fuel_entries::table
@@ -432,17 +390,14 @@ pub async fn fuel_entries_page(
                 .filter(vehicles::owner_id.eq(user_id))
                 .into_boxed();
 
-            // Apply vehicle filter
             if let Some(vid) = filter_vehicle_id {
                 query = query.filter(crate::schema::fuel_entries::vehicle_id.eq(vid));
             }
 
-            // Apply station filter
             if let Some(sid) = filter_station_id {
                 query = query.filter(crate::schema::fuel_entries::station_id.eq(sid));
             }
 
-            // Apply date filters
             if !filter_date_from_clone.is_empty()
                 && let Ok(date) =
                     chrono::NaiveDate::parse_from_str(&filter_date_from_clone, "%Y-%m-%d")
@@ -468,11 +423,8 @@ pub async fn fuel_entries_page(
                 ))
                 .load::<(crate::models::FuelEntry, Vehicle, Option<FuelStation>)>(conn)
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .await??;
 
-    // Calculate totals
     let total_entries = entries.len();
     let total_litres: f64 = entries.iter().map(|(e, _, _)| e.litres).sum();
     let total_cost: f64 = entries.iter().map(|(e, _, _)| e.cost).sum();
@@ -493,5 +445,5 @@ pub async fn fuel_entries_page(
         volume_unit: db_user.volume_unit,
     };
 
-    Ok(Html(template.render().map_err(internal_error)?))
+    Ok(Html(template.render()?))
 }

--- a/src/handlers/import.rs
+++ b/src/handlers/import.rs
@@ -2,7 +2,6 @@ use askama::Template;
 use axum::{
     Form, Router,
     extract::Multipart,
-    http::StatusCode,
     response::{Html, IntoResponse},
     routing::{get, post},
 };
@@ -11,10 +10,11 @@ use diesel::prelude::*;
 use serde::Serialize;
 use std::collections::HashMap;
 
-use super::{check_vehicle_write_access, internal_error};
+use super::check_vehicle_write_access;
 use crate::AppState;
 use crate::auth::{AuthUser, AuthUserRedirect};
 use crate::db::DbConn;
+use crate::error::AppError;
 use crate::models::{FuelStation, NewFuelStation, Vehicle};
 use crate::schema::{fuel_stations, vehicles};
 
@@ -57,13 +57,13 @@ pub async fn perform_import(
     vehicle_id: i32,
     csv_data: Vec<u8>,
     mappings: HashMap<String, String>,
-) -> Result<ImportResult, (StatusCode, String)> {
+) -> Result<ImportResult, AppError> {
     check_vehicle_write_access(conn, user_id, vehicle_id).await?;
 
     let mut reader = csv::Reader::from_reader(&csv_data[..]);
     let headers: Vec<String> = reader
         .headers()
-        .map_err(|e| (StatusCode::BAD_REQUEST, format!("CSV parse error: {}", e)))?
+        .map_err(|e| AppError::BadRequest(format!("CSV parse error: {}", e)))?
         .iter()
         .map(|s| s.to_string())
         .collect();
@@ -202,14 +202,7 @@ pub async fn perform_import(
                         .collect::<HashMap<_, _>>()
                 })
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("DB error: {}", e),
-            )
-        })?;
+        .await??;
 
     let mut stations_to_create: Vec<StationOp> = Vec::new();
     let stations_map = existing_stations;
@@ -319,14 +312,7 @@ pub async fn perform_import(
                 Ok((imported, skipped, stations_created, row_errors))
             })
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Transaction failed: {}", e),
-            )
-        })?;
+        .await??;
 
     let (imported, skipped, stations_created, mut row_errors) = result;
     let mut all_errors = parse_errors;
@@ -352,7 +338,7 @@ pub struct ImportTemplate {
 pub async fn import_page(
     DbConn(conn): DbConn,
     AuthUserRedirect(user): AuthUserRedirect,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     let user_id = user.user_id;
 
     let user_vehicles: Vec<Vehicle> = conn
@@ -362,15 +348,13 @@ pub async fn import_page(
                 .order(vehicles::registration)
                 .load::<Vehicle>(conn)
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .await??;
 
     let template = ImportTemplate {
         logged_in: true,
         vehicles: user_vehicles,
     };
-    Ok(Html(template.render().map_err(internal_error)?))
+    Ok(Html(template.render()?))
 }
 
 #[derive(Template)]
@@ -396,33 +380,34 @@ pub async fn htmx_import_preview(
     DbConn(conn): DbConn,
     user: AuthUser,
     mut multipart: Multipart,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     let mut csv_data: Option<Vec<u8>> = None;
     let mut vehicle_id: Option<i32> = None;
 
-    while let Some(field) = multipart.next_field().await.map_err(internal_error)? {
+    while let Some(field) = multipart.next_field().await? {
         let name = field.name().unwrap_or("").to_string();
-        let data = field.bytes().await.map_err(internal_error)?;
+        let data = field.bytes().await?;
 
         match name.as_str() {
             "file" => csv_data = Some(data.to_vec()),
             "vehicle_id" => {
-                vehicle_id =
-                    Some(String::from_utf8_lossy(&data).trim().parse().map_err(|_| {
-                        (StatusCode::BAD_REQUEST, "Invalid vehicle_id".to_string())
-                    })?);
+                vehicle_id = Some(
+                    String::from_utf8_lossy(&data)
+                        .trim()
+                        .parse()
+                        .map_err(|_| AppError::BadRequest("Invalid vehicle_id".to_string()))?,
+                );
             }
             _ => {}
         }
     }
 
     let vehicle_id =
-        vehicle_id.ok_or((StatusCode::BAD_REQUEST, "vehicle_id required".to_string()))?;
-    let csv_data = csv_data.ok_or((StatusCode::BAD_REQUEST, "No file uploaded".to_string()))?;
+        vehicle_id.ok_or_else(|| AppError::BadRequest("vehicle_id required".to_string()))?;
+    let csv_data = csv_data.ok_or_else(|| AppError::BadRequest("No file uploaded".to_string()))?;
 
     check_vehicle_write_access(&conn, user.user_id, vehicle_id).await?;
 
-    // Clean up any old imports for this user first
     let user_id = user.user_id;
     let _ = conn
         .interact(move |conn| {
@@ -436,10 +421,8 @@ pub async fn htmx_import_preview(
             )
             .execute(conn)
         })
-        .await
-        .map_err(internal_error)?;
+        .await??;
 
-    // Store CSV in temp_imports table
     let csv_data_clone = csv_data.clone();
     let temp_import: crate::models::TempImport = conn
         .interact(move |conn| {
@@ -451,14 +434,12 @@ pub async fn htmx_import_preview(
                 })
                 .get_result(conn)
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .await??;
 
     let mut reader = csv::Reader::from_reader(&csv_data[..]);
     let headers: Vec<String> = reader
         .headers()
-        .map_err(|e| (StatusCode::BAD_REQUEST, format!("CSV parse error: {}", e)))?
+        .map_err(|e| AppError::BadRequest(format!("CSV parse error: {}", e)))?
         .iter()
         .map(|s| s.to_string())
         .collect();
@@ -467,7 +448,7 @@ pub async fn htmx_import_preview(
         .records()
         .next()
         .transpose()
-        .map_err(|e| (StatusCode::BAD_REQUEST, format!("CSV parse error: {}", e)))?
+        .map_err(|e| AppError::BadRequest(format!("CSV parse error: {}", e)))?
         .map(|r| r.iter().map(|s| s.to_string()).collect::<Vec<_>>())
         .unwrap_or_else(|| vec!["".to_string(); headers.len()]);
 
@@ -501,7 +482,7 @@ pub async fn htmx_import_preview(
         sample_data: record,
         suggested_mappings,
     };
-    Ok(Html(template.render().map_err(internal_error)?))
+    Ok(Html(template.render()?))
 }
 
 #[derive(Template)]
@@ -519,51 +500,37 @@ pub async fn htmx_import_execute(
     DbConn(conn): DbConn,
     user: AuthUser,
     Form(payload): Form<std::collections::HashMap<String, String>>,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     let user_id = user.user_id;
 
-    // Extract import_id and vehicle_id from form
     let import_id = payload
         .get("import_id")
-        .ok_or((StatusCode::BAD_REQUEST, "import_id required".to_string()))?;
+        .ok_or_else(|| AppError::BadRequest("import_id required".to_string()))?;
     let vehicle_id = payload
         .get("vehicle_id")
-        .ok_or((StatusCode::BAD_REQUEST, "vehicle_id required".to_string()))?
+        .ok_or_else(|| AppError::BadRequest("vehicle_id required".to_string()))?
         .parse::<i32>()
-        .map_err(|_| (StatusCode::BAD_REQUEST, "Invalid vehicle_id".to_string()))?;
+        .map_err(|_| AppError::BadRequest("Invalid vehicle_id".to_string()))?;
 
-    // Parse import_id as UUID
-    let import_uuid = uuid::Uuid::parse_str(import_id).map_err(|_| {
-        (
-            StatusCode::BAD_REQUEST,
-            "Invalid import_id format".to_string(),
-        )
-    })?;
+    let import_uuid = uuid::Uuid::parse_str(import_id)
+        .map_err(|_| AppError::BadRequest("Invalid import_id format".to_string()))?;
 
-    // Retrieve CSV data from temp_imports table and verify ownership
     let temp_import: crate::models::TempImport = conn
         .interact(move |conn| {
             crate::schema::temp_imports::table
                 .filter(crate::schema::temp_imports::id.eq(import_uuid))
                 .filter(crate::schema::temp_imports::user_id.eq(user_id))
                 .first::<crate::models::TempImport>(conn)
+                .optional()
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|_| {
-            (
-                StatusCode::NOT_FOUND,
-                "Import not found or expired".to_string(),
-            )
-        })?;
+        .await??
+        .ok_or_else(|| AppError::NotFound("Import not found or expired".to_string()))?;
 
-    // Build mappings from form data
     let mut actual_mappings: HashMap<String, String> = HashMap::new();
-    let mut used_targets: HashMap<String, String> = HashMap::new(); // target -> column
+    let mut used_targets: HashMap<String, String> = HashMap::new();
     let mut i = 0;
     while let Some(col_name) = payload.get(&format!("col_{}", i)) {
         if let Some(target_field) = payload.get(&format!("map_{}", i)).filter(|s| !s.is_empty()) {
-            // Check if this target is already mapped to a different column
             if let Some(existing_col) = used_targets.get(target_field)
                 && existing_col != col_name
             {
@@ -578,7 +545,7 @@ pub async fn htmx_import_execute(
                         target_field, existing_col, col_name
                     )],
                 };
-                return Ok(Html(template.render().map_err(internal_error)?));
+                return Ok(Html(template.render()?));
             }
             used_targets.insert(target_field.clone(), col_name.clone());
             actual_mappings.insert(target_field.clone(), col_name.clone());
@@ -586,11 +553,9 @@ pub async fn htmx_import_execute(
         i += 1;
     }
 
-    // Perform the import
     let csv_data = temp_import.csv_data;
     let result = perform_import(&conn, user.user_id, vehicle_id, csv_data, actual_mappings).await?;
 
-    // Clean up the temp import after successful/failed execution
     let import_uuid_clone = import_uuid;
     let _ = conn
         .interact(move |conn| {
@@ -600,8 +565,7 @@ pub async fn htmx_import_execute(
             )
             .execute(conn)
         })
-        .await
-        .map_err(internal_error)?;
+        .await??;
 
     let template = if result.total_errors > 0 && result.imported == 0 {
         ImportResultTemplate {
@@ -623,7 +587,7 @@ pub async fn htmx_import_execute(
         }
     };
 
-    Ok(Html(template.render().map_err(internal_error)?))
+    Ok(Html(template.render()?))
 }
 
 fn normalize_station_name(name: &str) -> String {

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,19 +1,12 @@
 use axum::{
-    http::{HeaderMap, StatusCode},
+    http::HeaderMap,
     response::{IntoResponse, Redirect},
 };
 use diesel::prelude::*;
 
+use crate::error::AppError;
 use crate::models::Vehicle;
 use crate::schema::vehicles as vehicles_schema;
-
-/// Utility function for mapping any error into a `500 Internal Server Error`
-pub fn internal_error<E>(err: E) -> (StatusCode, String)
-where
-    E: std::fmt::Display,
-{
-    (StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
-}
 
 pub struct HxRedirect(pub &'static str);
 
@@ -27,18 +20,15 @@ impl IntoResponse for HxRedirect {
 
 pub const SUPPORTED_CURRENCIES: &[&str] = &["EUR", "GBP", "USD", "CAD", "AUD"];
 
-pub fn validate_currency(currency: &str) -> Result<(), (StatusCode, String)> {
+pub fn validate_currency(currency: &str) -> Result<(), AppError> {
     if SUPPORTED_CURRENCIES.contains(&currency) {
         Ok(())
     } else {
-        Err((
-            StatusCode::BAD_REQUEST,
-            format!(
-                "Unsupported currency '{}'. Must be one of: {}",
-                currency,
-                SUPPORTED_CURRENCIES.join(", ")
-            ),
-        ))
+        Err(AppError::BadRequest(format!(
+            "Unsupported currency '{}'. Must be one of: {}",
+            currency,
+            SUPPORTED_CURRENCIES.join(", ")
+        )))
     }
 }
 
@@ -46,7 +36,7 @@ pub async fn check_vehicle_write_access(
     conn: &deadpool_diesel::postgres::Object,
     user_id: i32,
     vehicle_id: i32,
-) -> Result<(), (StatusCode, String)> {
+) -> Result<(), AppError> {
     let has_write_access: (bool, bool) = conn
         .interact(move |conn| {
             let vehicle: Vehicle = vehicles_schema::table
@@ -70,22 +60,18 @@ pub async fn check_vehicle_write_access(
                 None => Ok((false, false)),
             }
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|_| (StatusCode::NOT_FOUND, "Vehicle not found".to_string()))?;
+        .await??;
 
     let (has_access, has_write) = has_write_access;
 
     if !has_access {
-        return Err((
-            StatusCode::FORBIDDEN,
+        return Err(AppError::Forbidden(
             "You don't have access to this vehicle".to_string(),
         ));
     }
 
     if !has_write {
-        return Err((
-            StatusCode::FORBIDDEN,
+        return Err(AppError::Forbidden(
             "You don't have write permission for this vehicle".to_string(),
         ));
     }
@@ -122,23 +108,6 @@ pub mod vehicles;
 mod tests {
     use super::*;
 
-    #[derive(Debug)]
-    struct TestError(String);
-
-    impl std::fmt::Display for TestError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{}", self.0)
-        }
-    }
-
-    impl std::error::Error for TestError {}
-
-    #[test]
-    fn test_internal_error_returns_500_status() {
-        let (status, _) = internal_error(TestError("boom".to_string()));
-        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
-    }
-
     #[test]
     fn test_validate_currency_accepts_all_supported_currencies() {
         for currency in SUPPORTED_CURRENCIES {
@@ -153,8 +122,8 @@ mod tests {
     fn test_validate_currency_rejects_unknown_currency() {
         let result = validate_currency("XYZ");
         assert!(result.is_err());
-        let (status, msg) = result.unwrap_err();
-        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let err = result.unwrap_err();
+        let msg = err.to_string();
         assert!(msg.contains("XYZ"));
         assert!(msg.contains("Must be one of"));
     }

--- a/src/handlers/settings.rs
+++ b/src/handlers/settings.rs
@@ -1,17 +1,17 @@
 use askama::Template;
 use axum::{
     Form, Router,
-    http::StatusCode,
     response::{Html, IntoResponse},
     routing::get,
 };
 use diesel::prelude::*;
 use serde::Deserialize;
 
-use super::{SUPPORTED_CURRENCIES, internal_error, validate_currency};
+use super::{SUPPORTED_CURRENCIES, validate_currency};
 use crate::AppState;
 use crate::auth::{AuthUser, AuthUserRedirect};
 use crate::db::DbConn;
+use crate::error::AppError;
 use crate::models::User;
 use crate::schema::users;
 
@@ -49,7 +49,7 @@ impl SettingsTemplate {
 pub async fn settings_page(
     DbConn(conn): DbConn,
     AuthUserRedirect(user): AuthUserRedirect,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     let user_id = user.user_id;
 
     let db_user: User = conn
@@ -58,9 +58,7 @@ pub async fn settings_page(
                 .filter(users::id.eq(user_id))
                 .first::<User>(conn)
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .await??;
 
     let template = SettingsTemplate {
         logged_in: true,
@@ -70,7 +68,7 @@ pub async fn settings_page(
         current_distance_unit: db_user.distance_unit,
         current_volume_unit: db_user.volume_unit,
     };
-    Ok(Html(template.render().map_err(internal_error)?))
+    Ok(Html(template.render()?))
 }
 
 #[derive(Deserialize)]
@@ -88,15 +86,14 @@ pub async fn update_settings(
     DbConn(conn): DbConn,
     user: AuthUser,
     Form(payload): Form<UpdateSettingsForm>,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     validate_currency(&payload.currency)?;
 
-    // Basic unit validation
     if !["km", "mi"].contains(&payload.distance_unit.as_str()) {
-        return Err((StatusCode::BAD_REQUEST, "Invalid distance unit".to_string()));
+        return Err(AppError::BadRequest("Invalid distance unit".to_string()));
     }
     if !["L", "gal"].contains(&payload.volume_unit.as_str()) {
-        return Err((StatusCode::BAD_REQUEST, "Invalid volume unit".to_string()));
+        return Err(AppError::BadRequest("Invalid volume unit".to_string()));
     }
 
     let user_id = user.user_id;
@@ -110,10 +107,8 @@ pub async fn update_settings(
             })
             .execute(conn)
     })
-    .await
-    .map_err(internal_error)?
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    .await??;
 
     let template = SettingsSuccessTemplate {};
-    Ok(Html(template.render().map_err(internal_error)?))
+    Ok(Html(template.render()?))
 }

--- a/src/handlers/stations.rs
+++ b/src/handlers/stations.rs
@@ -2,7 +2,6 @@ use askama::Template;
 use axum::{
     Form, Router,
     extract::Query,
-    http::StatusCode,
     response::{Html, IntoResponse},
     routing::{get, post},
 };
@@ -10,10 +9,11 @@ use diesel::prelude::*;
 use serde::Deserialize;
 use std::collections::HashMap;
 
-use super::{HxRedirect, fuzzy_match, internal_error};
+use super::{HxRedirect, fuzzy_match};
 use crate::AppState;
 use crate::auth::{AuthUser, AuthUserRedirect};
 use crate::db::DbConn;
+use crate::error::AppError;
 use crate::models::{FuelStation, NewFuelStation};
 use crate::schema::fuel_stations;
 
@@ -35,7 +35,7 @@ pub struct StationsTemplate {
 pub async fn stations_page(
     DbConn(conn): DbConn,
     AuthUserRedirect(user): AuthUserRedirect,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     let user_id = user.user_id;
 
     let stations: Vec<FuelStation> = conn
@@ -49,15 +49,13 @@ pub async fn stations_page(
                 .order(fuel_stations::name)
                 .load::<FuelStation>(conn)
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .await??;
 
     let template = StationsTemplate {
         logged_in: true,
         stations,
     };
-    Ok(Html(template.render().map_err(internal_error)?))
+    Ok(Html(template.render()?))
 }
 
 #[derive(Deserialize)]
@@ -69,7 +67,7 @@ pub async fn create_station(
     DbConn(conn): DbConn,
     user: AuthUser,
     Form(payload): Form<CreateStationForm>,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     let user_id = user.user_id;
 
     conn.interact(move |conn| {
@@ -80,9 +78,7 @@ pub async fn create_station(
             })
             .execute(conn)
     })
-    .await
-    .map_err(internal_error)?
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    .await??;
 
     Ok(HxRedirect("/stations"))
 }
@@ -97,7 +93,7 @@ pub async fn update_station(
     user: AuthUser,
     axum::extract::Path(station_id): axum::extract::Path<i32>,
     Form(payload): Form<UpdateStationForm>,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     let user_id = user.user_id;
 
     let is_owner: bool = conn
@@ -109,13 +105,11 @@ pub async fn update_station(
                 .first::<i32>(conn)
                 .optional()
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .await??
         .is_some();
 
     if !is_owner {
-        return Err((StatusCode::FORBIDDEN, "Access denied".to_string()));
+        return Err(AppError::Forbidden("Access denied".to_string()));
     }
 
     conn.interact(move |conn| {
@@ -125,9 +119,7 @@ pub async fn update_station(
             })
             .execute(conn)
     })
-    .await
-    .map_err(internal_error)?
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    .await??;
 
     Ok(HxRedirect("/stations"))
 }
@@ -142,20 +134,18 @@ pub async fn merge_stations(
     user: AuthUser,
     axum::extract::Path(source_id): axum::extract::Path<i32>,
     Form(payload): Form<MergeStationsForm>,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     let user_id = user.user_id;
     let target_id = payload.target_id;
 
     if source_id == target_id {
-        return Err((
-            StatusCode::BAD_REQUEST,
+        return Err(AppError::BadRequest(
             "Cannot merge station into itself".to_string(),
         ));
     }
 
     conn.interact(move |conn| {
         conn.transaction::<_, diesel::result::Error, _>(|conn| {
-            // Verify source station ownership
             let source_exists = fuel_stations::table
                 .filter(fuel_stations::id.eq(source_id))
                 .filter(fuel_stations::user_id.eq(user_id))
@@ -166,7 +156,6 @@ pub async fn merge_stations(
                 return Err(diesel::result::Error::NotFound);
             }
 
-            // Verify target station exists and is accessible
             let target_exists = fuel_stations::table
                 .filter(fuel_stations::id.eq(target_id))
                 .filter(
@@ -181,7 +170,6 @@ pub async fn merge_stations(
                 return Err(diesel::result::Error::NotFound);
             }
 
-            // Update fuel entries
             diesel::update(
                 crate::schema::fuel_entries::table
                     .filter(crate::schema::fuel_entries::station_id.eq(source_id)),
@@ -189,16 +177,13 @@ pub async fn merge_stations(
             .set(crate::schema::fuel_entries::station_id.eq(target_id))
             .execute(conn)?;
 
-            // Delete source station
             diesel::delete(fuel_stations::table.filter(fuel_stations::id.eq(source_id)))
                 .execute(conn)?;
 
             Ok(())
         })
     })
-    .await
-    .map_err(internal_error)?
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    .await??;
 
     Ok(HxRedirect("/stations"))
 }
@@ -207,7 +192,7 @@ pub async fn delete_station(
     DbConn(conn): DbConn,
     user: AuthUser,
     axum::extract::Path(station_id): axum::extract::Path<i32>,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     let user_id = user.user_id;
 
     let is_owner: bool = conn
@@ -219,21 +204,17 @@ pub async fn delete_station(
                 .first::<i32>(conn)
                 .optional()
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .await??
         .is_some();
 
     if !is_owner {
-        return Err((StatusCode::FORBIDDEN, "Access denied".to_string()));
+        return Err(AppError::Forbidden("Access denied".to_string()));
     }
 
     conn.interact(move |conn| {
         diesel::delete(fuel_stations::table.filter(fuel_stations::id.eq(station_id))).execute(conn)
     })
-    .await
-    .map_err(internal_error)?
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    .await??;
 
     Ok(Html(""))
 }
@@ -249,7 +230,7 @@ pub async fn htmx_station_search(
     DbConn(conn): DbConn,
     user: AuthUser,
     Query(params): Query<HashMap<String, String>>,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     let query = params.get("q").cloned().unwrap_or_default();
     let query_lower = query.to_lowercase();
 
@@ -259,7 +240,6 @@ pub async fn htmx_station_search(
 
     let user_id = user.user_id;
 
-    // Fetch all stations for the user (user's own + global)
     let stations: Vec<FuelStation> = conn
         .interact(move |conn| {
             fuel_stations::table
@@ -271,26 +251,20 @@ pub async fn htmx_station_search(
                 .order(fuel_stations::name)
                 .load::<FuelStation>(conn)
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .await??;
 
-    // Filter stations by fuzzy matching
     let filtered_stations: Vec<FuelStation> = stations
         .into_iter()
         .filter(|s| {
             let name_lower = s.name.to_lowercase();
-            // Check if query is a substring (case-insensitive)
-            name_lower.contains(&query_lower) ||
-            // Or if all query characters appear in order
-            fuzzy_match(&name_lower, &query_lower)
+            name_lower.contains(&query_lower) || fuzzy_match(&name_lower, &query_lower)
         })
-        .take(10) // Limit to 10 results
+        .take(10)
         .collect();
 
     let template = StationSearchResultsTemplate {
         stations: filtered_stations,
         query,
     };
-    Ok(Html(template.render().map_err(internal_error)?))
+    Ok(Html(template.render()?))
 }

--- a/src/handlers/stats.rs
+++ b/src/handlers/stats.rs
@@ -2,7 +2,6 @@ use askama::Template;
 use axum::{
     Router,
     extract::Query,
-    http::StatusCode,
     response::{Html, IntoResponse},
     routing::get,
 };
@@ -10,10 +9,10 @@ use diesel::prelude::*;
 use serde::Serialize;
 use std::collections::HashMap;
 
-use super::internal_error;
 use crate::AppState;
 use crate::auth::AuthUserRedirect;
 use crate::db::DbConn;
+use crate::error::AppError;
 use crate::models::{FuelStation, User, Vehicle};
 use crate::schema::{users, vehicles};
 
@@ -71,10 +70,9 @@ pub async fn stats_page(
     DbConn(conn): DbConn,
     AuthUserRedirect(user): AuthUserRedirect,
     Query(params): Query<HashMap<String, String>>,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     let user_id = user.user_id;
 
-    // Parse time period (default to "all")
     let period = params
         .get("period")
         .cloned()
@@ -84,10 +82,9 @@ pub async fn stats_page(
         "30d" => Some(chrono::Utc::now().naive_utc() - chrono::Duration::days(30)),
         "90d" => Some(chrono::Utc::now().naive_utc() - chrono::Duration::days(90)),
         "1y" => Some(chrono::Utc::now().naive_utc() - chrono::Duration::days(365)),
-        _ => None, // "all" or invalid
+        _ => None,
     };
 
-    // Get all fuel entries for the user's vehicles with vehicle and station info
     let entries: Vec<(crate::models::FuelEntry, Vehicle, Option<FuelStation>)> = conn
         .interact(move |conn| {
             let mut query = crate::schema::fuel_entries::table
@@ -109,9 +106,7 @@ pub async fn stats_page(
                 ))
                 .load::<(crate::models::FuelEntry, Vehicle, Option<FuelStation>)>(conn)
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .await??;
 
     let db_user: User = conn
         .interact(move |conn| {
@@ -119,9 +114,7 @@ pub async fn stats_page(
                 .filter(users::id.eq(user_id))
                 .first::<User>(conn)
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .await??;
 
     if entries.is_empty() {
         let empty_chart = ChartData {
@@ -145,15 +138,13 @@ pub async fn stats_page(
             volume_unit: db_user.volume_unit,
         };
 
-        return Ok(Html(template.render().map_err(internal_error)?));
+        return Ok(Html(template.render()?));
     }
 
-    // Calculate overall stats
     let total_entries = entries.len();
     let total_litres: f64 = entries.iter().map(|(e, _, _)| e.litres).sum();
     let total_cost: f64 = entries.iter().map(|(e, _, _)| e.cost).sum();
 
-    // Group entries by vehicle
     let mut vehicle_data: HashMap<
         i32,
         Vec<(crate::models::FuelEntry, Vehicle, Option<FuelStation>)>,
@@ -165,20 +156,18 @@ pub async fn stats_page(
             .push((entry, vehicle.clone(), station));
     }
 
-    // Vehicle colors for charts
     let vehicle_colors = [
-        "rgb(59, 130, 246)", // Blue
-        "rgb(16, 185, 129)", // Green
-        "rgb(139, 92, 246)", // Purple
-        "rgb(245, 158, 11)", // Orange
-        "rgb(239, 68, 68)",  // Red
-        "rgb(14, 165, 233)", // Sky
+        "rgb(59, 130, 246)",
+        "rgb(16, 185, 129)",
+        "rgb(139, 92, 246)",
+        "rgb(245, 158, 11)",
+        "rgb(239, 68, 68)",
+        "rgb(14, 165, 233)",
     ];
 
-    // Calculate vehicle stats and collect all unique dates
     let mut vehicle_stats = Vec::new();
     let mut all_dates: Vec<String> = Vec::new();
-    let mut vehicle_chart_data: HashMap<i32, Vec<(String, f64, f64, f64)>> = HashMap::new(); // vehicle_id -> [(date, efficiency, cost_per_km, cost_per_litre)]
+    let mut vehicle_chart_data: HashMap<i32, Vec<(String, f64, f64, f64)>> = HashMap::new();
 
     for (vehicle_id, vehicle_entries) in vehicle_data.iter() {
         let vehicle = &vehicle_entries[0].1;
@@ -241,7 +230,6 @@ pub async fn stats_page(
         vehicle_chart_data.insert(*vehicle_id, vehicle_points);
     }
 
-    // Sort dates and take last 20
     all_dates.sort();
     let labels: Vec<String> = all_dates
         .into_iter()
@@ -252,7 +240,6 @@ pub async fn stats_page(
         .rev()
         .collect();
 
-    // Build chart series for each vehicle
     let mut efficiency_series: Vec<ChartSeries> = Vec::new();
     let mut cost_per_km_series: Vec<ChartSeries> = Vec::new();
     let mut cost_per_litre_series: Vec<ChartSeries> = Vec::new();
@@ -266,7 +253,6 @@ pub async fn stats_page(
             .cloned()
             .unwrap_or_default();
 
-        // Create a map of date -> (efficiency, cost_per_km, cost_per_litre) for this vehicle
         let mut data_by_date: HashMap<&str, (f64, f64, f64)> = HashMap::new();
         for (date, eff, cpk, cpl) in &vehicle_points {
             data_by_date.insert(date.as_str(), (*eff, *cpk, *cpl));
@@ -327,7 +313,6 @@ pub async fn stats_page(
         series: cost_per_litre_series,
     };
 
-    // Calculate averages
     let avg_efficiency = if !vehicle_stats.is_empty() {
         vehicle_stats.iter().map(|v| v.avg_efficiency).sum::<f64>() / vehicle_stats.len() as f64
     } else {
@@ -363,5 +348,5 @@ pub async fn stats_page(
         volume_unit: db_user.volume_unit,
     };
 
-    Ok(Html(template.render().map_err(internal_error)?))
+    Ok(Html(template.render()?))
 }

--- a/src/handlers/vehicles.rs
+++ b/src/handlers/vehicles.rs
@@ -1,17 +1,17 @@
 use askama::Template;
 use axum::{
     Form, Router,
-    http::StatusCode,
     response::{Html, IntoResponse},
     routing::{delete, get},
 };
 use diesel::prelude::*;
 use serde::Deserialize;
 
-use super::{HxRedirect, internal_error};
+use super::HxRedirect;
 use crate::AppState;
 use crate::auth::{AuthUser, AuthUserRedirect};
 use crate::db::DbConn;
+use crate::error::AppError;
 use crate::models::{NewVehicle, Vehicle};
 use crate::schema::vehicles;
 
@@ -56,7 +56,7 @@ pub async fn create_vehicle(
     DbConn(conn): DbConn,
     user: AuthUser,
     Form(payload): Form<CreateVehicleForm>,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     let owner_id = user.user_id;
 
     conn.interact(move |conn| {
@@ -69,9 +69,7 @@ pub async fn create_vehicle(
             })
             .execute(conn)
     })
-    .await
-    .map_err(internal_error)?
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    .await??;
 
     Ok(HxRedirect("/dashboard"))
 }
@@ -94,7 +92,7 @@ pub struct VehicleListTemplate {
 pub async fn htmx_vehicles(
     DbConn(conn): DbConn,
     user: AuthUser,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     let user_id = user.user_id;
 
     let user_vehicles: Vec<Vehicle> = conn
@@ -104,21 +102,19 @@ pub async fn htmx_vehicles(
                 .order(vehicles::registration)
                 .load::<Vehicle>(conn)
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .await??;
 
     let template = VehicleListTemplate {
         vehicles: user_vehicles,
     };
-    Ok(Html(template.render().map_err(internal_error)?))
+    Ok(Html(template.render()?))
 }
 
 pub async fn htmx_delete_vehicle(
     DbConn(conn): DbConn,
     user: AuthUser,
     axum::extract::Path(id): axum::extract::Path<i32>,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     let user_id = user.user_id;
 
     conn.interact(move |conn| {
@@ -129,9 +125,7 @@ pub async fn htmx_delete_vehicle(
         )
         .execute(conn)
     })
-    .await
-    .map_err(internal_error)?
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    .await??;
 
     Ok(Html(""))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod auth;
 pub mod db;
+pub mod error;
 pub mod handlers;
 pub mod models;
 pub mod oauth_handlers;
 pub mod schema;
 pub mod state;
 
+pub use error::AppError;
 pub use state::AppState;

--- a/src/oauth_handlers.rs
+++ b/src/oauth_handlers.rs
@@ -14,7 +14,7 @@ use serde::Deserialize;
 use std::env;
 
 use crate::auth::extract_auth_user;
-use crate::handlers::internal_error;
+use crate::error::AppError;
 use crate::models::User;
 use crate::schema::users;
 use crate::state::AppState;
@@ -131,12 +131,12 @@ pub async fn google_callback(
     State(state): State<AppState>,
     req_headers: HeaderMap,
     axum::extract::Query(params): axum::extract::Query<CallbackParams>,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
+) -> Result<impl IntoResponse, AppError> {
     let csrf_cookie = extract_cookie(&req_headers, CSRF_COOKIE)
-        .ok_or((StatusCode::BAD_REQUEST, "Missing CSRF cookie".to_string()))?;
+        .ok_or_else(|| AppError::BadRequest("Missing CSRF cookie".to_string()))?;
 
     if csrf_cookie != params.state {
-        return Err((StatusCode::BAD_REQUEST, "CSRF state mismatch".to_string()));
+        return Err(AppError::BadRequest("CSRF state mismatch".to_string()));
     }
 
     let token_result = state
@@ -145,36 +145,21 @@ pub async fn google_callback(
         .exchange_code(AuthorizationCode::new(params.code))
         .request_async(async_http_client)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Token exchange failed: {e}"),
-            )
-        })?;
+        .map_err(|e| AppError::Internal(format!("Token exchange failed: {e}")))?;
 
     let user_info: GoogleUserInfo = reqwest::Client::new()
         .get("https://www.googleapis.com/oauth2/v3/userinfo")
         .bearer_auth(token_result.access_token().secret())
         .send()
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to fetch user info: {e}"),
-            )
-        })?
+        .map_err(|e| AppError::Internal(format!("Failed to fetch user info: {e}")))?
         .json()
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to parse user info: {e}"),
-            )
-        })?;
+        .map_err(|e| AppError::Internal(format!("Failed to parse user info: {e}")))?;
 
     let google_id = user_info.sub.clone();
     let email = user_info.email.clone();
-    let conn = state.pool.get().await.map_err(internal_error)?;
+    let conn = state.pool.get().await?;
 
     let user: User = conn
         .interact(move |conn| {
@@ -209,23 +194,13 @@ pub async fn google_callback(
                 .returning(User::as_returning())
                 .get_result(conn)
         })
-        .await
-        .map_err(internal_error)?
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Database error: {e}"),
-            )
-        })?;
+        .await??;
 
-    let jwt = state.auth.create_token(user.id, &user.email).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to create token: {e}"),
-        )
-    })?;
+    let jwt = state
+        .auth
+        .create_token(user.id, &user.email)
+        .map_err(|e| AppError::Internal(format!("Failed to create token: {e}")))?;
 
-    // Clear CSRF cookie and set auth cookie with JWT
     let clear_csrf_cookie = build_clear_cookie(CSRF_COOKIE);
     let auth_cookie = build_cookie("auth_token", &jwt, 604800);
 
@@ -245,8 +220,7 @@ pub struct CurrentUserResponse {
 pub async fn get_current_user(
     State(state): State<AppState>,
     req_headers: HeaderMap,
-) -> Result<impl IntoResponse, (StatusCode, String)> {
-    // Use extract_auth_user to support dev auth bypass
+) -> Result<impl IntoResponse, AppError> {
     let auth_user = extract_auth_user(&req_headers, &state.auth, &state.pool).await?;
 
     Ok(Json(CurrentUserResponse {


### PR DESCRIPTION
- Implement `AppError` enum with variants: `NotFound`, `BadRequest`, `Unauthorized`, `Forbidden`, `Internal`, `Database`
- Implement `IntoResponse` for `AppError` to render HTML error pages with `tracing::error!` logging
- Add `From` implementations for: `PoolError`, `InteractError`, `DieselError`, `askama::Error`, `MultipartError`
- Update all handlers (~25 across 8 files) to return `Result<impl IntoResponse, AppError>`
- Update `AuthUser` and `DbConn` extractors to use `AppError` as rejection type
- Use `?` operator throughout for cleaner error propagation
- Add `deadpool` dependency for `InteractError` type
