### PR TITLE
db: add indices for uniqueness and query performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "deesl"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "askama",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deesl"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 
 [lib]

--- a/migrations/2026-04-03-000000_add_fuel_entries_filled_at_index/down.sql
+++ b/migrations/2026-04-03-000000_add_fuel_entries_filled_at_index/down.sql
@@ -1,0 +1,2 @@
+-- Drop index on fuel_entries(filled_at)
+DROP INDEX IF EXISTS idx_fuel_entries_filled_at;

--- a/migrations/2026-04-03-000000_add_fuel_entries_filled_at_index/up.sql
+++ b/migrations/2026-04-03-000000_add_fuel_entries_filled_at_index/up.sql
@@ -1,0 +1,2 @@
+-- Add index on fuel_entries(filled_at) for faster stats queries
+CREATE INDEX idx_fuel_entries_filled_at ON fuel_entries(filled_at);

--- a/migrations/2026-04-03-000000_add_vehicles_registration_unique/down.sql
+++ b/migrations/2026-04-03-000000_add_vehicles_registration_unique/down.sql
@@ -1,0 +1,2 @@
+-- Drop unique index on vehicles(registration, owner_id)
+DROP INDEX IF EXISTS idx_vehicles_registration_owner;

--- a/migrations/2026-04-03-000000_add_vehicles_registration_unique/up.sql
+++ b/migrations/2026-04-03-000000_add_vehicles_registration_unique/up.sql
@@ -1,0 +1,2 @@
+-- Add unique index on vehicles(registration, owner_id)
+CREATE UNIQUE INDEX idx_vehicles_registration_owner ON vehicles(registration, owner_id);


### PR DESCRIPTION
- Add unique index on vehicles(registration, owner_id) to prevent duplicate registrations per user
- Add index on fuel_entries(filled_at) for faster stats query performance
- Verify cascade constraints exist on fuel_entries and vehicle_shares
- Bump version to 0.8.2

Fixes #46