### PR TITLE
Implement robust configuration management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "deesl"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "askama",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +290,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -571,6 +586,7 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "dotenvy",
+ "figment",
  "headers",
  "http 1.4.0",
  "http-security-headers",
@@ -779,6 +795,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "pear",
+ "serde",
+ "toml 0.8.23",
+ "uncased",
+ "version_check",
 ]
 
 [[package]]
@@ -1372,6 +1402,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
 name = "inventory"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,7 +1578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c791ecdf977c99f45f23280405d7723727470f6689a5e6dbf513ac547ae10d"
 dependencies = [
  "serde",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -1781,6 +1817,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,7 +1934,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -1885,6 +1944,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -2462,6 +2534,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
@@ -2847,15 +2928,36 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.0.4",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2869,12 +2971,26 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
@@ -2887,6 +3003,12 @@ checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -3072,6 +3194,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deesl"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2024"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ path = "src/lib.rs"
 name = "deesl"
 path = "src/main.rs"
 
+[features]
+default = []
+dev = []
+
 [dependencies]
 askama = { version = "0.12.1", features = ["serde-json"] }
 axum = { version = "0.8.8", features = ["json", "tokio", "form", "multipart"] }
@@ -22,6 +26,7 @@ deadpool-diesel = { version = "0.6.1", features = ["postgres"] }
 diesel = { version = "2.3.6", features = ["postgres", "chrono", "uuid"] }
 diesel_migrations = { version = "2.2.0", features = ["postgres"] }
 dotenvy = "0.15.7"
+figment = { version = "0.10.8", features = ["env", "toml"] }
 headers = "0.4"
 http = "1"
 jsonwebtoken = "9.3"

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 # Run server with reloading and trace logging enabled
 develop:
-    RUST_LOG=deesl=trace,tower_http=debug cargo watch -x run
+    RUST_LOG=deesl=trace,tower_http=debug cargo watch -x "run --features dev"
 
 # Format all Rust code
 fmt:

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -26,20 +26,24 @@ pub struct Claims {
 #[derive(Clone)]
 pub struct AuthConfig {
     pub secret: String,
+    pub expiration_hours: i64,
 }
 
 impl AuthConfig {
-    pub fn new() -> Self {
+    pub fn new(secret: &str, expiration_hours: i64) -> Self {
         Self {
-            secret: std::env::var(JWT_SECRET_KEY)
-                .unwrap_or_else(|_| "dev-secret-change-in-production".to_string()),
+            secret: secret.to_string(),
+            expiration_hours,
         }
     }
 }
 
 impl Default for AuthConfig {
     fn default() -> Self {
-        Self::new()
+        Self {
+            secret: "dev-secret-change-in-production".to_string(),
+            expiration_hours: 24 * 7,
+        }
     }
 }
 
@@ -50,7 +54,7 @@ impl AuthConfig {
         email: &str,
     ) -> Result<String, jsonwebtoken::errors::Error> {
         let expiration = chrono::Utc::now()
-            .checked_add_signed(chrono::Duration::hours(JWT_EXPIRATION_HOURS))
+            .checked_add_signed(chrono::Duration::hours(self.expiration_hours))
             .unwrap()
             .timestamp();
 
@@ -122,13 +126,14 @@ where
 }
 
 pub fn is_dev_auth_bypass_allowed(_headers: &HeaderMap) -> Option<String> {
-    // Layer 1: Compile-time check - only in debug builds
-    if cfg!(not(debug_assertions)) {
-        return None;
+    #[cfg(feature = "dev")]
+    {
+        std::env::var(DEV_AUTH_EMAIL_KEY).ok()
     }
-
-    // Layer 2: DEV_AUTH_EMAIL must be set
-    std::env::var(DEV_AUTH_EMAIL_KEY).ok()
+    #[cfg(not(feature = "dev"))]
+    {
+        None
+    }
 }
 
 pub async fn extract_auth_user(
@@ -177,6 +182,7 @@ mod tests {
     fn config_with_secret(secret: &str) -> AuthConfig {
         AuthConfig {
             secret: secret.to_string(),
+            expiration_hours: 24 * 7,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,99 @@
+use figment::Figment;
+use figment::providers::Env;
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AppConfig {
+    #[serde(default)]
+    pub server: ServerConfig,
+    #[serde(default)]
+    pub database: DatabaseConfig,
+    #[serde(default)]
+    pub oauth: OauthConfig,
+    #[serde(default)]
+    pub auth: AuthConfig,
+    #[serde(default)]
+    pub dev: DevConfig,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ServerConfig {
+    #[serde(default = "default_host")]
+    pub host: String,
+    #[serde(default = "default_port")]
+    pub port: usize,
+    #[serde(default = "default_base_url")]
+    pub base_url: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct DatabaseConfig {
+    #[serde(default)]
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct OauthConfig {
+    #[serde(default)]
+    pub google_client_id: String,
+    #[serde(default)]
+    pub google_client_secret: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct AuthConfig {
+    #[serde(default)]
+    pub jwt_secret: String,
+    #[serde(default = "default_jwt_expiration")]
+    pub jwt_expiration_hours: i64,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct DevConfig {
+    #[serde(default)]
+    pub dev_auth_email: Option<String>,
+}
+
+fn default_host() -> String {
+    "127.0.0.1".to_string()
+}
+
+fn default_port() -> usize {
+    8000
+}
+
+fn default_base_url() -> String {
+    "http://localhost:8000".to_string()
+}
+
+fn default_jwt_expiration() -> i64 {
+    24 * 7
+}
+
+impl AppConfig {
+    pub fn from_env() -> Result<Self, Box<dyn std::error::Error>> {
+        let mut config: Self = Figment::new().merge(Env::raw().split("_")).extract()?;
+
+        if config.server.host.is_empty() {
+            config.server.host = default_host();
+            config.server.port = default_port();
+            config.server.base_url = default_base_url();
+        }
+
+        if config.oauth.google_client_id.is_empty() {
+            config.oauth.google_client_id = std::env::var("GOOGLE_CLIENT_ID")?;
+        }
+        if config.oauth.google_client_secret.is_empty() {
+            config.oauth.google_client_secret = std::env::var("GOOGLE_CLIENT_SECRET")?;
+        }
+        if config.auth.jwt_secret.is_empty() {
+            config.auth.jwt_secret = std::env::var("JWT_SECRET")
+                .unwrap_or_else(|_| "dev-secret-change-in-production".to_string());
+        }
+        if config.auth.jwt_expiration_hours == 0 {
+            config.auth.jwt_expiration_hours = default_jwt_expiration();
+        }
+
+        Ok(config)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod config;
 pub mod db;
 pub mod error;
 pub mod handlers;
@@ -7,5 +8,6 @@ pub mod oauth_handlers;
 pub mod schema;
 pub mod state;
 
+pub use config::AppConfig;
 pub use error::AppError;
 pub use state::AppState;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,69 +1,43 @@
 use axum::{Router, routing::get};
 use deadpool_diesel::postgres::{Manager, Pool};
-use diesel::prelude::*;
 use http_security_headers::{
     ContentSecurityPolicy, CrossOriginEmbedderPolicy, CrossOriginOpenerPolicy,
     CrossOriginResourcePolicy, ReferrerPolicy, SecurityHeaders, SecurityHeadersLayer,
 };
-use std::env;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tower_http::trace::TraceLayer;
-use tower_livereload::LiveReloadLayer;
 use tracing::info;
 
-use deesl::{
-    AppState, auth::DEV_AUTH_EMAIL_KEY, handlers, models::NewUser, oauth_handlers, schema::users,
-};
+#[cfg(feature = "dev")]
+use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
+
+#[cfg(feature = "dev")]
+use tower_livereload::LiveReloadLayer;
+
+#[cfg(feature = "dev")]
+use deesl::{models::NewUser, schema::users};
+
+use deesl::{AppConfig, AppState, handlers, oauth_handlers};
 
 async fn serve_version() -> axum::response::Json<serde_json::Value> {
     const VERSION: &str = env!("CARGO_PKG_VERSION");
     axum::response::Json(serde_json::json!({ "version": VERSION }))
 }
 
-#[derive(Debug, Clone)]
-pub struct Config {
-    port: usize,
-    host: String,
-    database_url: String,
-    base_url: String,
-    environment: String,
-}
-
-impl Config {
-    pub fn from_env() -> Self {
-        dotenvy::dotenv().ok();
-
-        Self {
-            port: env::var("PORT")
-                .unwrap_or_else(|_| "8000".to_string())
-                .parse()
-                .expect("PORT must be a number"),
-            host: env::var("HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
-            database_url: env::var("DATABASE_URL").expect("DATABASE_URL must be set"),
-            base_url: env::var("BASE_URL").unwrap_or_else(|_| "http://localhost:8000".to_string()),
-            environment: env::var("ENVIRONMENT").unwrap_or_else(|_| "development".to_string()),
-        }
-    }
-
-    pub fn is_development(&self) -> bool {
-        self.environment == "development"
-    }
-}
-
 #[tokio::main]
 async fn main() {
+    dotenvy::dotenv().ok();
     tracing_subscriber::fmt::init();
 
-    let config = Config::from_env();
+    let config = AppConfig::from_env().expect("Failed to load configuration");
 
-    let manager = Manager::new(&config.database_url, deadpool_diesel::Runtime::Tokio1);
+    let manager = Manager::new(&config.database.url, deadpool_diesel::Runtime::Tokio1);
     let pool = Pool::builder(manager)
         .max_size(10)
         .build()
         .expect("Failed to create pool");
 
-    // Run migrations
     let conn = pool
         .get()
         .await
@@ -77,9 +51,9 @@ async fn main() {
     .await
     .expect("Failed to interact with database");
 
-    // Ensure dev user exists if dev auth is enabled
-    if config.is_development() && env::var(DEV_AUTH_EMAIL_KEY).is_ok() {
-        let dev_email = env::var(DEV_AUTH_EMAIL_KEY).unwrap();
+    #[cfg(feature = "dev")]
+    if let Some(dev_email) = &config.dev.dev_auth_email {
+        let dev_email = dev_email.clone();
         let pool_clone = pool.clone();
         tokio::spawn(async move {
             if let Ok(conn) = pool_clone.get().await {
@@ -110,11 +84,18 @@ async fn main() {
 
     let app_state = AppState {
         pool,
-        oauth: oauth_handlers::OAuthConfig::new(&config.base_url),
-        auth: deesl::auth::AuthConfig::new(),
+        oauth: oauth_handlers::OAuthConfig::new(
+            &config.oauth.google_client_id,
+            &config.oauth.google_client_secret,
+            &config.server.base_url,
+        ),
+        auth: deesl::auth::AuthConfig::new(
+            &config.auth.jwt_secret,
+            config.auth.jwt_expiration_hours,
+        ),
     };
 
-    let mut app = Router::new()
+    let app = Router::new()
         .route(
             "/",
             get(|| async { axum::response::Redirect::to("/dashboard") }),
@@ -133,11 +114,10 @@ async fn main() {
         .layer(build_security_headers())
         .with_state(app_state);
 
-    if config.is_development() {
-        app = app.layer(LiveReloadLayer::new());
-    }
+    #[cfg(feature = "dev")]
+    let app = app.layer(LiveReloadLayer::new());
 
-    let addr = format!("{}:{}", config.host, config.port);
+    let addr = format!("{}:{}", config.server.host, config.server.port);
     let listener = TcpListener::bind(&addr).await.unwrap();
     info!("listening on {}", addr);
     axum::serve(listener, app).await.unwrap();
@@ -171,34 +151,4 @@ fn build_security_headers() -> SecurityHeadersLayer {
         .unwrap();
 
     SecurityHeadersLayer::new(Arc::new(headers))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_config_is_development_when_environment_is_development() {
-        let config = Config::with_environment("development", vec![]);
-        assert!(config.is_development());
-    }
-
-    #[test]
-    fn test_config_is_not_development_when_environment_is_production() {
-        let config = Config::with_environment("production", vec![]);
-        assert!(!config.is_development());
-    }
-
-    impl Config {
-        #[cfg(test)]
-        pub fn with_environment(env: &str, _cors: Vec<String>) -> Self {
-            Self {
-                port: 8000,
-                host: "127.0.0.1".to_string(),
-                database_url: "postgres://localhost/deesl".to_string(),
-                base_url: "http://localhost:8000".to_string(),
-                environment: env.to_string(),
-            }
-        }
-    }
 }

--- a/src/oauth_handlers.rs
+++ b/src/oauth_handlers.rs
@@ -11,7 +11,6 @@ use oauth2::{
     TokenResponse, TokenUrl, basic::BasicClient, reqwest::async_http_client,
 };
 use serde::Deserialize;
-use std::env;
 
 use crate::auth::extract_auth_user;
 use crate::error::AppError;
@@ -21,20 +20,16 @@ use crate::state::AppState;
 
 const CSRF_COOKIE: &str = "oauth_csrf";
 
-fn is_development() -> bool {
-    env::var("ENVIRONMENT").unwrap_or_else(|_| "development".to_string()) == "development"
-}
-
-fn build_cookie(name: &str, value: &str, max_age: i64) -> String {
-    let secure_flag = if is_development() { "" } else { "; Secure" };
+fn build_cookie(name: &str, value: &str, max_age: i64, is_development: bool) -> String {
+    let secure_flag = if is_development { "" } else { "; Secure" };
     format!(
         "{}={}; HttpOnly; SameSite=Lax{}; Path=/; Max-Age={}",
         name, value, secure_flag, max_age
     )
 }
 
-fn build_clear_cookie(name: &str) -> String {
-    let secure_flag = if is_development() { "" } else { "; Secure" };
+fn build_clear_cookie(name: &str, is_development: bool) -> String {
+    let secure_flag = if is_development { "" } else { "; Secure" };
     format!(
         "{}=; HttpOnly; SameSite=Lax{}; Path=/; Max-Age=0",
         name, secure_flag
@@ -44,18 +39,16 @@ fn build_clear_cookie(name: &str) -> String {
 #[derive(Clone)]
 pub struct OAuthConfig {
     pub client: BasicClient,
+    pub is_development: bool,
 }
 
 impl OAuthConfig {
-    pub fn new(base_url: &str) -> Self {
-        let client_id = env::var("GOOGLE_CLIENT_ID").expect("GOOGLE_CLIENT_ID must be set");
-        let client_secret =
-            env::var("GOOGLE_CLIENT_SECRET").expect("GOOGLE_CLIENT_SECRET must be set");
+    pub fn new(client_id: &str, client_secret: &str, base_url: &str) -> Self {
         let redirect_url = format!("{}/auth/google/callback", base_url);
 
         let client = BasicClient::new(
-            ClientId::new(client_id),
-            Some(ClientSecret::new(client_secret)),
+            ClientId::new(client_id.to_string()),
+            Some(ClientSecret::new(client_secret.to_string())),
             AuthUrl::new("https://accounts.google.com/o/oauth2/v2/auth".to_string())
                 .expect("Invalid auth URL"),
             Some(
@@ -65,11 +58,13 @@ impl OAuthConfig {
         )
         .set_redirect_uri(RedirectUrl::new(redirect_url).expect("Invalid redirect URL"));
 
-        Self { client }
+        Self {
+            client,
+            is_development: cfg!(feature = "dev"),
+        }
     }
 
     pub fn test_config() -> Self {
-        // Create a dummy client for testing (won't be used for actual OAuth flow)
         let client = BasicClient::new(
             ClientId::new("test-client-id".to_string()),
             Some(ClientSecret::new("test-client-secret".to_string())),
@@ -85,7 +80,10 @@ impl OAuthConfig {
                 .expect("Invalid redirect URL"),
         );
 
-        Self { client }
+        Self {
+            client,
+            is_development: true,
+        }
     }
 }
 
@@ -106,7 +104,12 @@ pub async fn google_login(State(state): State<AppState>) -> impl IntoResponse {
         .add_scope(Scope::new("email".to_string()))
         .url();
 
-    let cookie = build_cookie(CSRF_COOKIE, csrf_token.secret(), 600);
+    let cookie = build_cookie(
+        CSRF_COOKIE,
+        csrf_token.secret(),
+        600,
+        state.oauth.is_development,
+    );
 
     let mut headers = HeaderMap::new();
     headers.insert(header::SET_COOKIE, cookie.parse().unwrap());
@@ -201,8 +204,8 @@ pub async fn google_callback(
         .create_token(user.id, &user.email)
         .map_err(|e| AppError::Internal(format!("Failed to create token: {e}")))?;
 
-    let clear_csrf_cookie = build_clear_cookie(CSRF_COOKIE);
-    let auth_cookie = build_cookie("auth_token", &jwt, 604800);
+    let clear_csrf_cookie = build_clear_cookie(CSRF_COOKIE, state.oauth.is_development);
+    let auth_cookie = build_cookie("auth_token", &jwt, 604800, state.oauth.is_development);
 
     let mut resp_headers = HeaderMap::new();
     resp_headers.insert(header::SET_COOKIE, clear_csrf_cookie.parse().unwrap());
@@ -230,7 +233,7 @@ pub async fn get_current_user(
 }
 
 pub async fn logout() -> impl IntoResponse {
-    let clear_cookie = build_clear_cookie("auth_token");
+    let clear_cookie = build_clear_cookie("auth_token", false);
     let mut resp_headers = HeaderMap::new();
     resp_headers.insert(header::SET_COOKIE, clear_cookie.parse().unwrap());
     (resp_headers, Redirect::to("/login"))

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -47,7 +47,7 @@ pub async fn create_test_app(pool: Pool) -> Router {
     let app_state = deesl::AppState {
         pool,
         oauth: oauth_handlers::OAuthConfig::test_config(),
-        auth: deesl::auth::AuthConfig::new(),
+        auth: deesl::auth::AuthConfig::new("test-secret", 168),
     };
 
     Router::new()
@@ -70,7 +70,7 @@ pub async fn create_test_app(pool: Pool) -> Router {
 
 /// Creates a JWT token for a test user
 pub fn create_test_token(user_id: i32, email: &str) -> String {
-    let auth_config = AuthConfig::new();
+    let auth_config = AuthConfig::new("test-secret", 168);
     auth_config.create_token(user_id, email).unwrap()
 }
 


### PR DESCRIPTION
- Add figment for centralized config with fail-fast at startup
- Add 'dev' feature for compile-time dev-only code (auth bypass, livereload)
- Support legacy env vars (GOOGLE_CLIENT_ID, JWT_SECRET, etc.) for backward compatibility
- Add server config with sensible defaults
- Update justfile to use dev feature

Closes #48